### PR TITLE
Feature/superset analysis

### DIFF
--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -820,23 +820,13 @@ def super_set(
     )
 
     for pair in pairs:
-        if hasattr(metric, "zero_division"):
-            result = metric(
-                data=data,
-                zero_division_=zero_division,
-                sensitive=list(pair),
-                real_target=real_target,
-                predicted_target=predicted_target,
-                positive_target=positive_target,
-            ).rank()
-        else:
-            result = metric(
-                data=data,
-                sensitive=list(pair),
-                real_target=real_target,
-                predicted_target=predicted_target,
-                positive_target=positive_target,
-            ).rank()
+        result = metric(
+            data=data,
+            sensitive=list(pair),
+            real_target=real_target,
+            predicted_target=predicted_target,
+            positive_target=positive_target,
+        ).rank()
 
         results.append(
             {

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -720,7 +720,90 @@ def super_set(
     positive_target: Sequence[int | float | str | bool] | None = None,
     zero_division: float | str | None = None,
 ) -> list:
+    """Calculate fairness metrics for different subsets of sensitive 
+    attributes. Ex: 
+    [gender, race] → (gender), (race), (gender, race)
 
+    Parameters
+    ----------
+    metric : type[DemographicParityDifference]  |  type[DemographicParityRatio]
+    |  type[DisparateImpactDifference]  |  type[DisparateImpactRatio]  |  
+    type[EqualOpportunityDifference]  |  type[EqualOpportunityRatio]  |  
+    type[EqualisedOddsDifference]  |  type[EqualisedOddsRatio]  |  
+    type[FalsePositiveRateDifference]  |  type[FalsePositiveRateRatio]
+        The fairness metric class to be used for evaluation
+    data : Dataset | pd.DataFrame
+        The dataset containing the data to be evaluated. If a DataFrame object
+        is passed, it should contain attributes `sensitive`, `real_target`,
+        `predicted_target`, and `positive_target`.
+    sensitive : Sequence[str], optional
+        A Sequence of sensitive attributes (Ex: gender, race...), by default []
+    real_target : Sequence[str] | None, optional
+        A Sequence of column names of actual labels for target variables, 
+        by default None
+    predicted_target : Sequence[str] | None, optional
+        A Sequence of column names of predicted labels for target variables, 
+        by default None
+    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
+        A Sequence of the positive labels corresponding to the provided 
+        targets, by default None
+    zero_division : float | str | None, optional
+        Value to use when there is a zero division situation, by default None
+
+    Returns
+    -------
+    list
+        list
+        A list of dictionaries, each containing the sensitive attributes 
+        considered and their corresponding fairness metric result.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({
+    ...         'gender': ['male', 'male', 'male', 'female', 'female'],
+    ...         'race': ['white', 'black', 'black', 'white', 'white'],
+    ...         'real': [1,1,0,0,1],
+    ...         'pred': [0,1,0,0,1]
+    ... })
+    >>> result = super_set(
+    ...     metric=DemographicParityDifference,
+    ...     data=df,
+    ...     sensitive=['gender', 'race'],
+    ...     real_target=['real'],
+    ...     predicted_target=['pred'],
+    ... )
+    >>> result
+    [
+        {
+            'sensitive': ('gender',),
+            'result': {
+                'real': {
+                    ('male',): 0.16666666666666663,
+                    ('female',): -0.16666666666666663
+                }
+            }
+        },
+        {
+            'sensitive': ('race',),
+            'result': {
+                'real': {
+                    ('white',): 0.16666666666666663,
+                    ('black',): -0.16666666666666663
+                }
+            }
+        },
+        {
+            'sensitive': ('gender', 'race'),
+            'result': {
+                'real': {
+                    ('male', 'white'): 0.5,
+                    ('female', 'white'): -0.25,
+                    ('male', 'black'): -0.25
+                }
+            }
+        }
+    ]
+    """
     results = []
 
     if isinstance(data, Dataset):

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -1,4 +1,5 @@
 from collections.abc import Collection, Sequence
+from itertools import chain, combinations
 
 import numpy as np
 import pandas as pd
@@ -697,3 +698,60 @@ class EqualisedOddsRatio:
                 bias[target] = False
 
         return bias
+
+
+def super_set(
+    metric: (
+        FairnessMetricDifference
+        | FairnessMetricRatio
+        | EqualisedOddsDifference
+        | EqualisedOddsRatio
+    ),
+    data: Dataset | pd.DataFrame,
+    sensitive: Sequence[str] | None = None,
+    real_target: Sequence[str] | None = None,
+    predicted_target: Sequence[str] | None = None,
+    positive_target: Sequence[int | float | str | bool] | None = None,
+    zero_division: float | str | None = None,
+) -> list:
+
+    results = []
+
+    if isinstance(data, Dataset):
+        sensitive = data.sensitive
+        real_target = data.real_target
+        predicted_target = data.predicted_target
+        positive_target = data.positive_target
+        data = data.df
+
+    pairs = chain.from_iterable(
+        combinations(sensitive, r) for r in range(1, len(sensitive) + 1)
+    )
+
+    for pair in pairs:
+        if hasattr(metric, "zero_division"):
+            result = metric(
+                data=data,
+                zero_division_=zero_division,
+                sensitive=list(pair),
+                real_target=real_target,
+                predicted_target=predicted_target,
+                positive_target=positive_target,
+            ).rank()
+        else:
+            result = metric(
+                data=data,
+                sensitive=list(pair),
+                real_target=real_target,
+                predicted_target=predicted_target,
+                positive_target=positive_target,
+            ).rank()
+
+        results.append(
+            {
+                "sensitive": pair,
+                "result": result,
+            }
+        )
+
+    return results

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -723,6 +723,8 @@ def super_set(
         predicted_target = data.predicted_target
         positive_target = data.positive_target
         data = data.df
+        if predicted_target == []:
+            predicted_target = None
 
     pairs = chain.from_iterable(
         combinations(sensitive, r) for r in range(1, len(sensitive) + 1)

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -702,13 +702,19 @@ class EqualisedOddsRatio:
 
 def super_set(
     metric: (
-        FairnessMetricDifference
-        | FairnessMetricRatio
-        | EqualisedOddsDifference
-        | EqualisedOddsRatio
+        type[DemographicParityDifference]
+        | type[DemographicParityRatio]
+        | type[DisparateImpactDifference]
+        | type[DisparateImpactRatio]
+        | type[EqualOpportunityDifference]
+        | type[EqualOpportunityRatio]
+        | type[EqualisedOddsDifference]
+        | type[EqualisedOddsRatio]
+        | type[FalsePositiveRateDifference]
+        | type[FalsePositiveRateRatio]
     ),
     data: Dataset | pd.DataFrame,
-    sensitive: Sequence[str] | None = None,
+    sensitive: Sequence[str] = [],
     real_target: Sequence[str] | None = None,
     predicted_target: Sequence[str] | None = None,
     positive_target: Sequence[int | float | str | bool] | None = None,

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -720,16 +720,16 @@ def super_set(
     positive_target: Sequence[int | float | str | bool] | None = None,
     zero_division: float | str | None = None,
 ) -> list:
-    """Calculate fairness metrics for different subsets of sensitive 
-    attributes. Ex: 
+    """Calculate fairness metrics for different subsets of sensitive
+    attributes. Ex:
     [gender, race] → (gender), (race), (gender, race)
 
     Parameters
     ----------
     metric : type[DemographicParityDifference]  |  type[DemographicParityRatio]
-    |  type[DisparateImpactDifference]  |  type[DisparateImpactRatio]  |  
-    type[EqualOpportunityDifference]  |  type[EqualOpportunityRatio]  |  
-    type[EqualisedOddsDifference]  |  type[EqualisedOddsRatio]  |  
+    |  type[DisparateImpactDifference]  |  type[DisparateImpactRatio]  |
+    type[EqualOpportunityDifference]  |  type[EqualOpportunityRatio]  |
+    type[EqualisedOddsDifference]  |  type[EqualisedOddsRatio]  |
     type[FalsePositiveRateDifference]  |  type[FalsePositiveRateRatio]
         The fairness metric class to be used for evaluation
     data : Dataset | pd.DataFrame
@@ -739,13 +739,13 @@ def super_set(
     sensitive : Sequence[str], optional
         A Sequence of sensitive attributes (Ex: gender, race...), by default []
     real_target : Sequence[str] | None, optional
-        A Sequence of column names of actual labels for target variables, 
+        A Sequence of column names of actual labels for target variables,
         by default None
     predicted_target : Sequence[str] | None, optional
-        A Sequence of column names of predicted labels for target variables, 
+        A Sequence of column names of predicted labels for target variables,
         by default None
     positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        A Sequence of the positive labels corresponding to the provided 
+        A Sequence of the positive labels corresponding to the provided
         targets, by default None
     zero_division : float | str | None, optional
         Value to use when there is a zero division situation, by default None
@@ -754,7 +754,7 @@ def super_set(
     -------
     list
         list
-        A list of dictionaries, each containing the sensitive attributes 
+        A list of dictionaries, each containing the sensitive attributes
         considered and their corresponding fairness metric result.
 
     Examples

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -24,10 +24,14 @@ from fair_mango.metrics.metrics import (
     EqualisedOddsRatio,
     EqualOpportunityDifference,
     EqualOpportunityRatio,
+    FalsePositiveRateDifference,
+    FalsePositiveRateRatio,
     PerformanceMetric,
     SelectionRate,
     false_negative_rate,
     false_positive_rate,
+    is_binary,
+    super_set,
     true_negative_rate,
 )
 
@@ -1553,3 +1557,141 @@ def test_equalised_odds_ratio(
             else:
                 eor = EqualisedOddsRatio(data, sensitive, real_target, predicted_target)
             eor.summary()
+
+
+expected_result_1 = [
+    {
+        "sensitive": ("Sex",),
+        "result": {
+            "HeartDisease": {("M",): 0.3726567804180811, ("F",): -0.3726567804180811}
+        },
+    }
+]
+expected_result_2 = [
+    {
+        "sensitive": ("Sex",),
+        "result": {
+            "HeartDisease": {("M",): 0.4219830636141608, ("F",): 2.369763353617309}
+        },
+    },
+    {
+        "sensitive": ("ChestPainType",),
+        "result": {
+            "HeartDisease": {
+                ("ASY",): 0.3917632113245289,
+                ("TA",): 0.9779803774692927,
+                ("NAP",): 1.3200622150699777,
+                ("ATA",): 3.612010526994567,
+            }
+        },
+    },
+    {
+        "sensitive": ("Sex", "ChestPainType"),
+        "result": {
+            "HeartDisease": {
+                ("M", "ASY"): 0.3468836645650188,
+                ("F", "ASY"): 0.5421518990141162,
+                ("M", "TA"): 0.6173483803022393,
+                ("M", "NAP"): 0.7690055427507021,
+                ("M", "ATA"): 2.1240334935639593,
+                ("F", "TA"): 3.869338673817374,
+                ("F", "ATA"): 4.671777837152278,
+                ("F", "NAP"): 5.173302314236593,
+            }
+        },
+    },
+]
+
+
+expected_result_3 = [
+    {
+        "sensitive": ("Sex",),
+        "result": {
+            "HeartDisease": {("M",): 0.03816593886462882, ("F",): -0.03816593886462882}
+        },
+    },
+    {
+        "sensitive": ("ChestPainType",),
+        "result": {
+            "HeartDisease": {
+                ("NAP",): 0.048316838338099695,
+                ("ASY",): 0.04340882369780954,
+                ("ATA",): 0.025394519369986518,
+                ("TA",): -0.11712018140589575,
+            }
+        },
+    },
+    {
+        "sensitive": ("Sex", "ChestPainType"),
+        "result": {
+            "HeartDisease": {
+                ("F", "TA"): 0.10053586843924016,
+                ("F", "ATA"): 0.09033178680658709,
+                ("M", "NAP"): 0.08199377127623639,
+                ("M", "ASY"): 0.08153282325925479,
+                ("M", "ATA"): 0.05205550855335028,
+                ("F", "ASY"): 0.0014697534603408588,
+                ("M", "TA"): -0.16240914536313006,
+                ("F", "NAP"): -0.24551036643187954,
+            }
+        },
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "metric, data, sensitive, real_target, predicted_target, expected_result",
+    [
+        (
+            DemographicParityDifference,
+            dataset1,
+            [],
+            None,
+            None,
+            expected_result_1,
+        ),
+        (
+            DisparateImpactRatio,
+            df,
+            ["Sex", "ChestPainType"],
+            ["HeartDisease"],
+            ["HeartDiseasePred"],
+            expected_result_2,
+        ),
+        (
+            EqualisedOddsDifference,
+            dataset3,
+            [],
+            None,
+            None,
+            expected_result_3,
+        ),
+    ],
+)
+def test_super_set(
+    metric: (
+        type[DemographicParityDifference]
+        | type[DemographicParityRatio]
+        | type[DisparateImpactDifference]
+        | type[DisparateImpactRatio]
+        | type[EqualOpportunityDifference]
+        | type[EqualOpportunityRatio]
+        | type[EqualisedOddsDifference]
+        | type[EqualisedOddsRatio]
+        | type[FalsePositiveRateDifference]
+        | type[FalsePositiveRateRatio]
+    ),
+    data: pd.DataFrame | Dataset,
+    sensitive: Sequence[str],
+    real_target: Sequence[str] | None,
+    predicted_target: Sequence[str] | None,
+    expected_result: Sequence[dict[str, dict]] | RaisesContext,
+):
+    result = super_set(
+        metric,
+        data,
+        sensitive,
+        real_target,
+        predicted_target,
+    )
+    assert result == expected_result

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -30,7 +30,6 @@ from fair_mango.metrics.metrics import (
     SelectionRate,
     false_negative_rate,
     false_positive_rate,
-    is_binary,
     super_set,
     true_negative_rate,
 )


### PR DESCRIPTION
This enhancement allows the study for multiple combinations of the sensitive groups in one function.

Example: If we have the sensitive features as `['gender', 'race']` then we would the results for:
- groups spliced by `gender`.
- groups spliced by `race`.
- groups spliced by the combination of `gender` and `race`.

PS: All the tests run successfully on my MacBook. 