### PR TITLE
ENH: Refactor fairness metrics to rely solely on Dataset class

### DIFF
--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -20,7 +20,6 @@ def check_column_existence_in_df(df: pd.DataFrame, columns: Sequence[str]) -> No
     KeyError
         If the one of the columns does not exist in the dataframe.
     """
-
     for column in columns:
         if column not in df.columns:
             raise (
@@ -170,27 +169,21 @@ class Dataset:
         else:
             self.groups = (
                 df[sensitive]
-                .groupby(sensitive)
+                .groupby(list(sensitive))
                 .size()
                 .reset_index(name="Count")
                 .sort_values("Count", ascending=False)
             )
         self.n_groups: int = len(self.groups)
-        self.groups_data: list[dict[str, np.ndarray | pd.DataFrame]] = []
-        self.groups_real_target: (
-            list[dict[str, np.ndarray | pd.Series | pd.DataFrame]] | None
-        ) = None
-        self.groups_predicted_target: (
-            list[dict[str, np.ndarray | pd.Series | pd.DataFrame]] | None
-        ) = None
+        self.groups_data: list[dict[str, pd.DataFrame]] = []
+        self.groups_real_target: list[dict[str, pd.DataFrame]] | None = None
+        self.groups_predicted_target: list[dict[str, pd.DataFrame]] | None = None
         plt.style.use("fivethirtyeight")
 
-    def get_data_for_all_groups(self) -> list[dict[str, np.ndarray | pd.DataFrame]]:
+    def get_data_for_all_groups(self) -> list[dict[str, pd.DataFrame]]:
         """Retrieve data corresponding to each sensitive group present in
         the sensitive features.
 
-        Tip
-        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the data for the combination
         of the two sensitive features; Hence, all of the following groups:
@@ -232,6 +225,7 @@ class Dataset:
                     0        male       white      ...         0                 no
                     3        male       black      ...         0                yes
                     4        male       black      ...         0                yes
+
                 [3 rows x 8 columns]
             },
             {
@@ -239,6 +233,7 @@ class Dataset:
                 'data':   sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
                      1      female       white     ...        1                 no
                      2      female       black     ...        1                yes
+
                 [2 rows x 8 columns]
             }
         ]
@@ -256,24 +251,28 @@ class Dataset:
                 'data':   sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
                     3        male       black      ...         0                yes
                     4        male       black      ...         0                yes
+
                 [2 rows x 8 columns]
             },
             {
                 'sensitive': array(['female', 'black'], dtype=object),
                 'data':   sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
                     2      female       black      ...         1                yes
+
                 [1 rows x 8 columns]
             },
             {
                 'sensitive': array(['female', 'white'], dtype=object),
                 'data':   sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
                     1      female       white      ...         1                 no
+
                 [1 rows x 8 columns]
             },
             {
                 'sensitive': array(['male', 'white'], dtype=object),
                 'data':   sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
                     0        male       white      ...         0                 no
+
                 [1 rows x 8 columns]
             }
         ]
@@ -289,12 +288,20 @@ class Dataset:
         """Retrieve data corresponding to a specific sensitive group present
         in the sensitive features.
 
+        If you have two sensitive attributes `gender` (male, female) and `race`
+        (white, black), this function would return the data for the combination
+        of the two sensitive features; Hence, it expects the `sensitive_group`
+        parameter to match the `sensitive` parameter when  creating the
+        `Dataset`. For example: `sensitive = ['Sex', 'Race']` then
+        `sensitive_group = ['male', 'Asian']` (The order of the values matters
+        and exchanging the places will not work!)
+
         Parameters
         ----------
-        sensitive_group : Sequence[str]
+        sensitive : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
-            `sensitive`. For instance, if your `sensitive` attributes were
+            `sensitive`. For instance, if your `sensitive` attribute were
             `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
 
         Returns
@@ -328,6 +335,7 @@ class Dataset:
             sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
         1      female       white    ...         1                 no
         2      female       black    ...         1                yes
+
         [2 rows x 8 columns]
         >>> dataset2 = Dataset(
         ...     df=df,
@@ -340,6 +348,7 @@ class Dataset:
             sensitive_1 sensitive_2  ... predicted_target_1 predicted_target_2
         3        male       black    ...         0                yes
         4        male       black    ...         0                yes
+
         [2 rows x 8 columns]
         """
         result = None
@@ -352,7 +361,10 @@ class Dataset:
                 if (all(e1 in item["sensitive"] for e1 in sensitive_group)) and (
                     all(e2 in sensitive_group for e2 in item["sensitive"])
                 ):
-                    result = item["data"]
+                    if isinstance(item["data"], np.ndarray):
+                        result = pd.DataFrame(item["data"])
+                    else:
+                        result = item["data"]
         if result is None:
             raise (
                 ValueError(f"{sensitive_group} group does not exist in the dataframe")
@@ -361,12 +373,10 @@ class Dataset:
 
     def get_real_target_for_all_groups(
         self,
-    ) -> list[dict[str, np.ndarray | pd.Series | pd.DataFrame]]:
+    ) -> list[dict[str, pd.DataFrame]]:
         """Retrieve the real target corresponding to each sensitive group
         present in the sensitive features.
 
-        Tip
-        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the real target for the
         combination of the two sensitive features; Hence, all of the following
@@ -451,7 +461,7 @@ class Dataset:
             for i in range(len(self.sensitive)):
                 result = result[result[self.sensitive[i]] == row[i]]
             self.groups_real_target.append(
-                {"sensitive": row[:-1], "data": result[self.real_target].squeeze()}
+                {"sensitive": row[:-1], "data": result[self.real_target]}
             )
         return self.groups_real_target
 
@@ -461,9 +471,17 @@ class Dataset:
         """Retrieve the real target corresponding to a specific sensitive
         group present in the sensitive features.
 
+        If you have two sensitive attributes `gender` (male, female) and `race`
+        (white, black), this function would return the real target for the
+        combination of the two sensitive features; Hence, it expects the
+        `sensitive_group` parameter to match the `sensitive` parameter when
+        creating the `Dataset`. For example: `sensitive = ['Sex', 'Race']` then
+        `sensitive_group = ['male', 'Asian']` (The order of the values matters
+        and exchanging the places will not work!)
+
         Parameters
         ----------
-        sensitive_group : Sequence[str]
+        sensitive : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
             `sensitive`. For instance, if your `sensitive` attribute were
@@ -523,7 +541,10 @@ class Dataset:
                 if (item["sensitive"] == sensitive_group).all() or (
                     item["sensitive"] == sensitive_group[::-1]
                 ).all():
-                    result = item["data"]
+                    if isinstance(item["data"], (np.ndarray, pd.Series)):
+                        result = pd.DataFrame(item["data"])
+                    else:
+                        result = item["data"]
         if result is None:
             raise (
                 ValueError(f"{sensitive_group} group does not exist in the dataframe")
@@ -532,12 +553,10 @@ class Dataset:
 
     def get_predicted_target_for_all_groups(
         self,
-    ) -> list[dict[str, np.ndarray | pd.Series | pd.DataFrame]]:
+    ) -> list[dict[str, pd.DataFrame]]:
         """Retrieve the predicted target corresponding to each sensitive
         group present in the sensitive features.
 
-        Tip
-        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the predicted target for the
         combination of the two sensitive features; Hence, all of the following
@@ -625,8 +644,9 @@ class Dataset:
             result = self.df
             for i in range(len(self.sensitive)):
                 result = result[result[self.sensitive[i]] == row[i]]
+            print(result[self.predicted_target].shape)
             self.groups_predicted_target.append(
-                {"sensitive": row[:-1], "data": result[self.predicted_target].squeeze()}
+                {"sensitive": row[:-1], "data": result[self.predicted_target]}
             )
         return self.groups_predicted_target
 
@@ -636,13 +656,21 @@ class Dataset:
         """Retrieve the predicted target corresponding to a specific sensitive
         group present in the sensitive features.
 
+        If you have two sensitive attributes `gender` (male, female) and `race`
+        (white, black), this function would return the predicted target for the
+        combination of the two sensitive features; Hence, it expects the
+        `sensitive_group` parameter to match the `sensitive` parameter when
+        creating the `Dataset`. For example: `sensitive = ['Sex', 'Race']` then
+        `sensitive_group = ['male', 'Asian']` (The order of the values matters
+        and exchanging the places will not work!)
+
         Parameters
         ----------
-        sensitive_group : Sequence[str]
+        sensitive : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
             `sensitive`. For instance, if your `sensitive` attribute were
-            `['Sex', 'Race']`, you can pass `sensitive_group=['male', 'Asian']`.
+            `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
 
         Returns
         -------
@@ -702,7 +730,10 @@ class Dataset:
                 if (item["sensitive"] == sensitive_group).all() or (
                     item["sensitive"] == sensitive_group[::-1]
                 ).all():
-                    result = item["data"]
+                    if isinstance(item["data"], (np.ndarray, pd.Series)):
+                        result = pd.DataFrame(item["data"])
+                    else:
+                        result = item["data"]
         if result is None:
             raise (
                 ValueError(f"{sensitive_group} group does not exist in the dataframe")

--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -489,7 +489,7 @@ class Dataset:
         sensitive : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
-            `sensitive`. For instance, if your `sensitive` attribute were
+            `sensitive`. For instance, if your `sensitive` attributes were
             `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
 
         Returns

--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -184,6 +184,8 @@ class Dataset:
         """Retrieve data corresponding to each sensitive group present in
         the sensitive features.
 
+        Tip
+        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the data for the combination
         of the two sensitive features; Hence, all of the following groups:
@@ -288,6 +290,8 @@ class Dataset:
         """Retrieve data corresponding to a specific sensitive group present
         in the sensitive features.
 
+        Tip
+        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the data for the combination
         of the two sensitive features; Hence, it expects the `sensitive_group`
@@ -298,7 +302,7 @@ class Dataset:
 
         Parameters
         ----------
-        sensitive : Sequence[str]
+        sensitive_group : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
             `sensitive`. For instance, if your `sensitive` attribute were
@@ -361,10 +365,7 @@ class Dataset:
                 if (all(e1 in item["sensitive"] for e1 in sensitive_group)) and (
                     all(e2 in sensitive_group for e2 in item["sensitive"])
                 ):
-                    if isinstance(item["data"], np.ndarray):
-                        result = pd.DataFrame(item["data"])
-                    else:
-                        result = item["data"]
+                    result = item["data"]
         if result is None:
             raise (
                 ValueError(f"{sensitive_group} group does not exist in the dataframe")
@@ -377,6 +378,8 @@ class Dataset:
         """Retrieve the real target corresponding to each sensitive group
         present in the sensitive features.
 
+        Tip
+        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the real target for the
         combination of the two sensitive features; Hence, all of the following
@@ -471,6 +474,8 @@ class Dataset:
         """Retrieve the real target corresponding to a specific sensitive
         group present in the sensitive features.
 
+        Tip
+        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the real target for the
         combination of the two sensitive features; Hence, it expects the
@@ -557,6 +562,8 @@ class Dataset:
         """Retrieve the predicted target corresponding to each sensitive
         group present in the sensitive features.
 
+        Tip
+        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the predicted target for the
         combination of the two sensitive features; Hence, all of the following
@@ -656,6 +663,8 @@ class Dataset:
         """Retrieve the predicted target corresponding to a specific sensitive
         group present in the sensitive features.
 
+        Tip
+        ---
         If you have two sensitive attributes `gender` (male, female) and `race`
         (white, black), this function would return the predicted target for the
         combination of the two sensitive features; Hence, it expects the

--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -305,7 +305,7 @@ class Dataset:
         sensitive_group : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
-            `sensitive`. For instance, if your `sensitive` attribute were
+            `sensitive`. For instance, if your `sensitive` attributes were
             `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
 
         Returns
@@ -651,7 +651,6 @@ class Dataset:
             result = self.df
             for i in range(len(self.sensitive)):
                 result = result[result[self.sensitive[i]] == row[i]]
-            print(result[self.predicted_target].shape)
             self.groups_predicted_target.append(
                 {"sensitive": row[:-1], "data": result[self.predicted_target]}
             )

--- a/fair_mango/metrics/base.py
+++ b/fair_mango/metrics/base.py
@@ -1,10 +1,11 @@
-from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from abc import ABC
+from collections.abc import Hashable, Sequence
 from itertools import combinations
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from fair_mango.dataset.dataset import Dataset
 
@@ -34,7 +35,7 @@ def is_binary(y: pd.Series | pd.DataFrame) -> bool:
             return False
 
 
-def encode_target(data: Dataset, ind: int, col: str) -> None:
+def encode_target(data: Dataset, ind: int, col: str | Hashable) -> None:
     """encode targets as [0,1]
 
     Parameters
@@ -151,20 +152,8 @@ class Metric(ABC):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Raises
     ------
@@ -174,43 +163,35 @@ class Metric(ABC):
         - If the target variable is not binary (has two unique values).
     """
 
-    def __init__(
-        self,
-        data: Dataset | pd.DataFrame,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ) -> None:
-        if isinstance(data, Dataset):
-            self.data = data
-        else:
-            if sensitive is None or real_target is None:
-                raise ValueError(
-                    "When providing a DataFrame, 'sensitive' and 'real_target'"
-                    " must be specified."
-                )
-            self.data = Dataset(
-                data, sensitive, real_target, predicted_target, positive_target
-            )
-
+    def __init__(self, data: Dataset) -> None:
+        self.data = data
         self.predicted_targets_by_group = []
-        y = self.data.df[self.data.real_target]
+        y: Any = self.data.df[self.data.real_target]
         if len(self.data.real_target) > 1:
             y = y.squeeze()
         if is_binary(y):
-            for ind, col in enumerate(y):
-                if (np.unique(y[col]) != [0, 1]).all():
-                    encode_target(self.data, ind, col)
+            if isinstance(y, pd.Series):
+                if (np.unique(y) != [0, 1]).all():
+                    encode_target(self.data, 0, y.name)
+            else:
+                for ind, col in enumerate(y.columns):
+                    if (np.unique(y[col]) != [0, 1]).all():
+                        encode_target(self.data, ind, col)
+
             self.real_targets_by_group = self.data.get_real_target_for_all_groups()
+
             if self.data.predicted_target != []:
                 y = self.data.df[self.data.predicted_target]
                 if len(self.data.predicted_target) > 1:
                     y = y.squeeze()
                 if is_binary(y):
-                    for ind, col in enumerate(y):
-                        if (np.unique(y[col]) != [0, 1]).all():
-                            encode_target(self.data, ind, col)
+                    if isinstance(y, pd.Series):
+                        if (np.unique(y) != [0, 1]).all():
+                            encode_target(self.data, 0, y.name)
+                    else:
+                        for ind, col in enumerate(y.columns):
+                            if (np.unique(y[col]) != [0, 1]).all():
+                                encode_target(self.data, ind, str(col))
                 self.predicted_targets_by_group = (
                     self.data.get_predicted_target_for_all_groups()
                 )
@@ -222,13 +203,13 @@ class Metric(ABC):
                 )
             )
 
-    @abstractmethod
-    def __call__(self): ...
+    def __call__(self):
+        pass
 
 
 def calculate_disparity(
     result_per_groups: list[dict], method: Literal["difference", "ratio"]
-) -> dict[tuple, np.ndarray[float]]:
+) -> dict[tuple, NDArray[np.float64]]:
     """Calculate the disparity in the scores between every possible pair in
     the provided groups using two available methods:
     - difference (Example: for three groups a, b, c:
@@ -281,8 +262,7 @@ def calculate_disparity(
             result[key] = result_i / result_j
         else:
             raise AttributeError(
-                f"method {method} not recognised. Use 'difference' or "
-                "'ratio' instead."
+                f"method {method} not recognised. Use 'difference' or 'ratio' instead."
             )
 
     return result
@@ -295,25 +275,13 @@ class FairnessMetricDifference(ABC):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     metric : type[Metric]
         A sequence of metrics or a dictionary with keys being custom labels
         and values a callable that calculates the score.
     label : str
         The key to give to the result in the different returned dictionaries.
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
     metric_type : str, optional
         Whether the metric measures performance or error. Either 'performance'
         or 'error', by default 'performance'.
@@ -329,35 +297,19 @@ class FairnessMetricDifference(ABC):
 
     def __init__(
         self,
-        data: Dataset | pd.DataFrame,
+        data: Dataset,
         metric: type[Metric],
         label: str,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
         metric_type: str = "performance",
         **kwargs,
     ) -> None:
-        if isinstance(data, Dataset):
-            self.data = data
-        else:
-            if sensitive is None or real_target is None:
-                raise ValueError(
-                    "When providing a DataFrame, 'sensitive' and 'real_target'"
-                    " must be specified."
-                )
-            self.data = Dataset(
-                data, sensitive, real_target, predicted_target, positive_target
-            )
-
         self.metric = metric
         self.label = label
         self.kwargs = kwargs
         self.targets: Sequence
         self.metric_results: list
         self.metric_type = metric_type
-
+        self.data = data
         if metric_type == "performance":
             self.label1 = "privileged"
             self.label2 = "unprivileged"
@@ -366,15 +318,14 @@ class FairnessMetricDifference(ABC):
             self.label2 = "privileged"
         else:
             raise AttributeError(
-                "Metric type not recognized. accepted values 'performance' or "
-                "'error'"
+                "Metric type not recognized. accepted values 'performance' or 'error'"
             )
 
         self.result: dict | None = None
         self.ranking: dict | None = None
         self.results: dict | None = None
 
-    def _compute(self) -> dict[tuple, np.ndarray[float]]:
+    def _compute(self) -> dict[tuple, NDArray[np.float64]]:
         """Calculate the disparity in the scores between every possible pair in
         the provided groups.
 
@@ -531,25 +482,13 @@ class FairnessMetricRatio(ABC):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     metric : type[Metric]
         A sequence of metrics or a dictionary with keys being custom labels
         and values a callable that calculates the score.
     label : str
         The key to give to the result in the different returned dictionaries.
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
     metric_type : str, optional
         Whether the metric measures performance or error. Either 'performance'
         or 'error', by default 'performance'.
@@ -565,26 +504,13 @@ class FairnessMetricRatio(ABC):
 
     def __init__(
         self,
-        data: Dataset | pd.DataFrame,
+        data: Dataset,
         metric: type[Metric],
         label: str,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
         metric_type: str = "performance",
         **kwargs,
     ) -> None:
-        if isinstance(data, Dataset):
-            self.data = data
-        else:
-            if sensitive is None or real_target is None:
-                raise ValueError(
-                    "When providing a DataFrame, 'sensitive' and 'real_target' must be specified."
-                )
-            self.data = Dataset(
-                data, sensitive, real_target, predicted_target, positive_target
-            )
+        self.data = data
         self.metric = metric
 
         if metric_type == "performance":
@@ -595,8 +521,7 @@ class FairnessMetricRatio(ABC):
             self.label2 = "privileged"
         else:
             raise AttributeError(
-                "Metric type not recognized. accepted values 'performance' or "
-                "'error'"
+                "Metric type not recognized. accepted values 'performance' or 'error'"
             )
 
         self.kwargs = kwargs
@@ -608,7 +533,7 @@ class FairnessMetricRatio(ABC):
         self.ranking: dict | None = None
         self.results: dict | None = None
 
-    def _compute(self) -> dict[tuple, np.ndarray[float]]:
+    def _compute(self) -> dict[tuple, NDArray[np.float64]]:
         """Calculate the disparity in the scores between every possible pair in
         the provided groups.
 

--- a/fair_mango/metrics/base.py
+++ b/fair_mango/metrics/base.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Hashable, Sequence
 from itertools import combinations
 from typing import Any, Literal
@@ -203,6 +203,7 @@ class Metric(ABC):
                 )
             )
 
+    @abstractmethod
     def __call__(self):
         pass
 

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -1,9 +1,9 @@
 from collections.abc import Collection, Sequence
-from typing import overload
 
 import numpy as np
 import pandas as pd
-from sklearn.metrics import (
+from numpy.typing import NDArray
+from sklearn.metrics import (  # type: ignore
     accuracy_score,
     balanced_accuracy_score,
     confusion_matrix,
@@ -52,33 +52,14 @@ class SelectionRate(Metric):
         by default None.
     """
 
-    @overload
-    def __init__(self, data: Dataset, use_y_true: bool, label: str = "result"): ...
-
-    @overload
     def __init__(
         self,
-        data: pd.DataFrame,
-        use_y_true: bool,
-        sensitive: Sequence[str],
-        real_target: Sequence[str],
-        predicted_target: Sequence[str],
-        positive_target: Sequence[int | float | str | bool],
-        label: str,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        use_y_true=False,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
-        label="result",
+        data: Dataset,
+        use_y_true: bool = False,
+        label: str = "result",
     ):
         super().__init__(
-            data, sensitive, real_target, predicted_target, positive_target
+            data,
         )
         self.use_y_true = use_y_true
         self.label = label
@@ -309,36 +290,12 @@ class ConfusionMatrix(Metric):
         to the sensitive groups.
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         metrics: Collection | Sequence | None = None,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        metrics: Collection | None = None,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        metrics=None,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
-        super().__init__(
-            data, sensitive, real_target, predicted_target, positive_target
-        )
+        super().__init__(data)
         if self.predicted_targets_by_group == []:
             raise ValueError(
                 "No predictions found, provide predicted_target parameter "
@@ -355,7 +312,7 @@ class ConfusionMatrix(Metric):
             if isinstance(metrics, dict):
                 if "sensitive" in metrics.keys():
                     raise KeyError(
-                        "metric label cannot be 'sensitive'. Change the label " "to fix"
+                        "metric label cannot be 'sensitive'. Change the label to fix"
                     )
                 self.metrics = metrics
             else:
@@ -496,9 +453,8 @@ class ConfusionMatrix(Metric):
                     real_values = real_y_group[real_col]
                     predicted_values = predicted_y_group[predicted_col]
                 else:
-                    real_values = real_y_group
-                    predicted_values = predicted_y_group
-
+                    real_values = real_y_group.iloc[:, 0]
+                    predicted_values = predicted_y_group.iloc[:, 0]
                 conf_matrix = confusion_matrix(
                     real_values, predicted_values, labels=[0, 1]
                 )
@@ -508,9 +464,12 @@ class ConfusionMatrix(Metric):
                 fp = conf_matrix[0, 1]
 
                 for metric_name, metric in self.metrics.items():
-                    result_for_group.setdefault(metric_name, []).append(
-                        metric(tn=tn, fp=fp, fn=fn, tp=tp)  # type: ignore[call-arg]
+                    if metric_name not in result_for_group:
+                        result_for_group[metric_name] = []  # type: ignore
+                    result_for_group[metric_name].append(  # type: ignore
+                        metric(tn=tn, fp=fp, fn=fn, tp=tp)  # type: ignore
                     )
+
             results.append(result_for_group)
 
         return self.data.real_target, results
@@ -527,7 +486,7 @@ class PerformanceMetric(Metric):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     metrics : set[Callable] | dict[str, Callable] | None, optional
         A sequence of metrics or a dictionary with keys being custom labels
@@ -540,18 +499,6 @@ class PerformanceMetric(Metric):
         - f1_score_score().
         or any custom metric that takes y_true and y_pred and parameters
         respectively.
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Raises
     ------
@@ -562,36 +509,12 @@ class PerformanceMetric(Metric):
         to the sensitive groups.
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         metrics: Collection | None = None,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        metrics: Collection | None = None,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        metrics=None,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
-        super().__init__(
-            data, sensitive, real_target, predicted_target, positive_target
-        )
+        super().__init__(data)
 
         if self.predicted_targets_by_group == []:
             raise ValueError(
@@ -612,7 +535,7 @@ class PerformanceMetric(Metric):
             if isinstance(metrics, dict):
                 if "sensitive" in metrics.keys():
                     raise KeyError(
-                        "metric label cannot be 'sensitive'. Change the label " "to fix"
+                        "metric label cannot be 'sensitive'. Change the label to fix"
                     )
                 self.metrics = metrics
 
@@ -759,11 +682,13 @@ class PerformanceMetric(Metric):
                     real_values = real_y_group[real_col]
                     predicted_values = predicted_y_group[predicted_col]
                 else:
-                    real_values = real_y_group
-                    predicted_values = predicted_y_group
+                    real_values = real_y_group.iloc[:, 0]
+                    predicted_values = predicted_y_group.iloc[:, 0]
 
                 for metric_name, metric in self.metrics.items():
-                    result_for_group.setdefault(metric_name, []).append(
+                    if metric_name not in result_for_group:
+                        result_for_group[metric_name] = []  # type: ignore
+                    result_for_group[metric_name].append(  # type: ignore
                         metric(real_values, predicted_values)
                     )
 
@@ -786,23 +711,11 @@ class DemographicParityDifference(FairnessMetricDifference):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     label : str
         The key to give to the result in the different returned dictionaries,
         by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -843,41 +756,15 @@ class DemographicParityDifference(FairnessMetricDifference):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "demographic_parity_difference",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "demographic_parity_difference",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="demographic_parity_difference",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             SelectionRate,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "performance",
             **{"use_y_true": True},
         )
@@ -897,23 +784,11 @@ class DisparateImpactDifference(FairnessMetricDifference):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     label : str
         The key to give to the result in the different returned dictionaries,
         by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -954,41 +829,15 @@ class DisparateImpactDifference(FairnessMetricDifference):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "disparate_impact_difference",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "disparate_impact_difference",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="disparate_impact_difference",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             SelectionRate,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "performance",
             **{"use_y_true": False},
         )
@@ -1008,23 +857,11 @@ class EqualOpportunityDifference(FairnessMetricDifference):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     label : str
         The key to give to the result in the different returned dictionaries,
         by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1065,41 +902,15 @@ class EqualOpportunityDifference(FairnessMetricDifference):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "equal_opportunity_difference",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "equal_opportunity_difference",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="equal_opportunity_difference",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             ConfusionMatrix,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "performance",
             **{"metrics": {"result": true_positive_rate}},
         )
@@ -1121,23 +932,11 @@ class FalsePositiveRateDifference(FairnessMetricDifference):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     label : str
         The key to give to the result in the different returned dictionaries,
         by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1178,41 +977,15 @@ class FalsePositiveRateDifference(FairnessMetricDifference):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "false_positive_rate_difference",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "false_positive_rate_difference",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="false_positive_rate_difference",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             ConfusionMatrix,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "error",
             **{"metrics": {"result": false_positive_rate}},
         )
@@ -1232,23 +1005,8 @@ class DemographicParityRatio(FairnessMetricRatio):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
-    label : str
-        The key to give to the result in the different returned dictionaries,
-        by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1289,41 +1047,15 @@ class DemographicParityRatio(FairnessMetricRatio):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "demographic_parity_ratio",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "demographic_parity_ratio",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="demographic_parity_ratio",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             SelectionRate,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "performance",
             **{"use_y_true": True},
         )
@@ -1343,23 +1075,8 @@ class DisparateImpactRatio(FairnessMetricRatio):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
-    label : str
-        The key to give to the result in the different returned dictionaries,
-        by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1400,41 +1117,15 @@ class DisparateImpactRatio(FairnessMetricRatio):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "disparate_impact_ratio",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "disparate_impact_ratio",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="disparate_impact_ratio",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             SelectionRate,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "performance",
             **{"use_y_true": False},
         )
@@ -1454,23 +1145,11 @@ class EqualOpportunityRatio(FairnessMetricRatio):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     label : str
         The key to give to the result in the different returned dictionaries,
         by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1511,41 +1190,15 @@ class EqualOpportunityRatio(FairnessMetricRatio):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "equal_opportunity_ratio",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "equal_opportunity_ratio",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="equal_opportunity_ratio",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             ConfusionMatrix,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "performance",
             **{"metrics": {"result": true_positive_rate}},
         )
@@ -1566,23 +1219,11 @@ class FalsePositiveRateRatio(FairnessMetricRatio):
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
     label : str
         The key to give to the result in the different returned dictionaries,
         by default "demographic_parity_difference".
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1623,41 +1264,15 @@ class FalsePositiveRateRatio(FairnessMetricRatio):
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
         label: str = "false_positive_rate_ratio",
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        label: str = "false_positive_rate_ratio",
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        label="false_positive_rate_ratio",
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
         super().__init__(
             data,
             ConfusionMatrix,
             label,
-            sensitive,
-            real_target,
-            predicted_target,
-            positive_target,
             "error",
             **{"metrics": {"result": false_positive_rate}},
         )
@@ -1683,20 +1298,8 @@ class EqualisedOddsDifference:
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -1737,43 +1340,11 @@ class EqualisedOddsDifference:
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
-        if isinstance(data, Dataset):
-            self.data = data
-        else:
-            if sensitive is None or real_target is None:
-                raise ValueError(
-                    "When providing a DataFrame, 'sensitive' and 'real_target'"
-                    " must be specified."
-                )
-
-            self.data = Dataset(
-                data, sensitive, real_target, predicted_target, positive_target
-            )
-
+        self.data = data
         self.label = "equalised_odds_difference"
         self.ranking: dict | None = None
         self.tpr: dict | None = None
@@ -1781,7 +1352,7 @@ class EqualisedOddsDifference:
 
     def _compute(
         self,
-    ) -> tuple[dict[tuple, np.ndarray[float]], dict[tuple, np.ndarray[float]]]:
+    ) -> tuple[dict[tuple, NDArray[np.float64]], dict[tuple, NDArray[np.float64]]]:
         """Calculate the disparity in the True Positive Rate and False Positive
         Rate using "difference" between every possible pair in the provided
         groups.
@@ -1963,20 +1534,8 @@ class EqualisedOddsRatio:
 
     Parameters
     ----------
-    data : Dataset | pd.DataFrame
+    data : Dataset
         Input data.
-    sensitive : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to sensitive features
-        (Ex: gender, race...), by default None.
-    real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
-        (true labels), by default None.
-    predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
-        by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
-        by default None.
 
     Examples
     --------
@@ -2017,43 +1576,11 @@ class EqualisedOddsRatio:
     }
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        sensitive: Sequence[str] | None = None,
-        real_target: Sequence[str] | None = None,
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
-        if isinstance(data, Dataset):
-            self.data = data
-        else:
-            if sensitive is None or real_target is None:
-                raise ValueError(
-                    "When providing a DataFrame, 'sensitive' and 'real_target'"
-                    " must be specified."
-                )
-
-            self.data = Dataset(
-                data, sensitive, real_target, predicted_target, positive_target
-            )
-
+        self.data = data
         self.label = "equalised_odds_ratio"
         self.ranking: dict | None = None
         self.tpr: dict | None = None

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -58,9 +58,7 @@ class SelectionRate(Metric):
         use_y_true: bool = False,
         label: str = "result",
     ):
-        super().__init__(
-            data,
-        )
+        super().__init__(data)
         self.use_y_true = use_y_true
         self.label = label
 
@@ -679,8 +677,8 @@ class PerformanceMetric(Metric):
                 self.data.real_target, self.data.predicted_target
             ):
                 if len(self.data.real_target) != 1:
-                    real_values = real_y_group[real_col]
-                    predicted_values = predicted_y_group[predicted_col]
+                    real_values: pd.Series = real_y_group[real_col]
+                    predicted_values: pd.Series = predicted_y_group[predicted_col]
                 else:
                     real_values = real_y_group.iloc[:, 0]
                     predicted_values = predicted_y_group.iloc[:, 0]

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -671,7 +671,7 @@ class PerformanceMetric(Metric):
             group_ = real_group["sensitive"]
             real_y_group = real_group["data"]
             predicted_y_group = predicted_group["data"]
-            result_for_group = {"sensitive": group_}
+            result_for_group: dict[str, list | pd.DataFrame] = {"sensitive": group_}
 
             for real_col, predicted_col in zip(
                 self.data.real_target, self.data.predicted_target
@@ -685,8 +685,8 @@ class PerformanceMetric(Metric):
 
                 for metric_name, metric in self.metrics.items():
                     if metric_name not in result_for_group:
-                        result_for_group[metric_name] = []  # type: ignore
-                    result_for_group[metric_name].append(  # type: ignore
+                        result_for_group[metric_name] = []
+                    result_for_group[metric_name].append(
                         metric(real_values, predicted_values)
                     )
 

--- a/fair_mango/metrics/superset.py
+++ b/fair_mango/metrics/superset.py
@@ -1,9 +1,5 @@
 from abc import ABC
-from collections.abc import Sequence
 from itertools import chain, combinations
-from typing import overload
-
-import pandas as pd
 
 from fair_mango.dataset.dataset import Dataset
 from fair_mango.metrics.metrics import (
@@ -50,39 +46,17 @@ class Superset(ABC):
         If data is a pandas dataframe and 'sensitive' parameter is not provided.
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        sensitive: Sequence[str],
-        real_target: Sequence[str],
-        predicted_target: Sequence[str],
-        positive_target: Sequence[int | float | str | bool],
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
-        if isinstance(data, Dataset):
-            sensitive = data.sensitive
-            real_target = data.real_target
-            predicted_target = data.predicted_target
-            positive_target = data.positive_target
-            data = data.df
-            if predicted_target == []:
-                predicted_target = None
-
+        sensitive = data.sensitive
+        real_target = data.real_target
+        predicted_target = data.predicted_target
+        positive_target = data.positive_target
+        df = data.df
+        if predicted_target == []:
+            predicted_target = None  # type: ignore
         if sensitive is None:
             raise AttributeError(
                 "'sensitive' attribute is required when data is pandas dataframe"
@@ -92,7 +66,7 @@ class Superset(ABC):
             combinations(sensitive, r) for r in range(1, len(sensitive) + 1)
         )
 
-        self.data = data
+        self.df = df
         self.sensitive = sensitive
         self.real_target = real_target
         self.predicted_target = predicted_target
@@ -130,7 +104,6 @@ class SupersetFairnessMetrics(Superset):
         targets, by default None.
     """
 
-    @overload
     def __init__(
         self,
         metric: (
@@ -146,42 +119,8 @@ class SupersetFairnessMetrics(Superset):
             | type[FalsePositiveRateRatio]
         ),
         data: Dataset,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        metric: (
-            type[DemographicParityDifference]
-            | type[DemographicParityRatio]
-            | type[DisparateImpactDifference]
-            | type[DisparateImpactRatio]
-            | type[EqualOpportunityDifference]
-            | type[EqualOpportunityRatio]
-            | type[EqualisedOddsDifference]
-            | type[EqualisedOddsRatio]
-            | type[FalsePositiveRateDifference]
-            | type[FalsePositiveRateRatio]
-        ),
-        data: pd.DataFrame,
-        sensitive: Sequence[str],
-        real_target: Sequence[str],
-        predicted_target: Sequence[str],
-        positive_target: Sequence[int | float | str | bool],
-    ): ...
-
-    def __init__(
-        self,
-        metric,
-        data,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
     ) -> None:
-        super().__init__(
-            data, sensitive, real_target, predicted_target, positive_target
-        )
+        super().__init__(data)
         self.metric = metric
 
     def rank(self) -> list:
@@ -246,13 +185,15 @@ class SupersetFairnessMetrics(Superset):
         results = []
 
         for pair in self.pairs:
-            result = self.metric(
-                data=self.data,
-                sensitive=list(pair),
-                real_target=self.real_target,
-                predicted_target=self.predicted_target,
-                positive_target=self.positive_target,
-            ).rank()
+            dataset = Dataset(
+                self.df,
+                list(pair),
+                self.real_target,
+                self.predicted_target,
+                self.positive_target,
+            )
+
+            result = self.metric(dataset).rank()
 
             results.append(
                 {
@@ -288,33 +229,11 @@ class SupersetPerformanceMetrics(Superset):
         targets, by default None.
     """
 
-    @overload
     def __init__(
         self,
         data: Dataset,
-    ): ...
-
-    @overload
-    def __init__(
-        self,
-        data: pd.DataFrame,
-        sensitive: Sequence[str],
-        real_target: Sequence[str],
-        predicted_target: Sequence[str],
-        positive_target: Sequence[int | float | str | bool],
-    ): ...
-
-    def __init__(
-        self,
-        data,
-        sensitive=None,
-        real_target=None,
-        predicted_target=None,
-        positive_target=None,
-    ) -> None:
-        super().__init__(
-            data, sensitive, real_target, predicted_target, positive_target
-        )
+    ):
+        super().__init__(data)
         self.metrics = [SelectionRate, PerformanceMetric, ConfusionMatrix]
 
     def evaluate(self) -> list[dict]:
@@ -379,35 +298,28 @@ class SupersetPerformanceMetrics(Superset):
         results = []
 
         for pair in self.pairs:
+            dataset = Dataset(
+                self.df,
+                list(pair),
+                self.real_target,
+                self.predicted_target,
+                self.positive_target,
+            )
             concatenated_results = SelectionRate(
-                data=self.data,
+                data=dataset,
                 use_y_true=True,
-                sensitive=list(pair),
-                real_target=self.real_target,
-                predicted_target=self.predicted_target,
-                positive_target=self.positive_target,
                 label="selection_rate_in_data",
             )()
 
             for metric in self.metrics:
                 if metric is SelectionRate:
                     result = SelectionRate(
-                        data=self.data,
+                        data=dataset,
                         use_y_true=False,
-                        sensitive=list(pair),
-                        real_target=self.real_target,
-                        predicted_target=self.predicted_target,
-                        positive_target=self.positive_target,
                         label="selection_rate_in_predictions",
                     )()[1]
                 else:
-                    result = metric(
-                        data=self.data,
-                        sensitive=list(pair),
-                        real_target=self.real_target,
-                        predicted_target=self.predicted_target,
-                        positive_target=self.positive_target,
-                    )()[1]
+                    result = metric(data=dataset)()[1]
 
                 for concatenated_result, res in zip(concatenated_results[1], result):
                     concatenated_result.update(res)

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,8 +1,9 @@
 from collections.abc import Sequence
+from contextlib import AbstractContextManager
 
+import numpy as np
 import pandas as pd
 import pytest
-from _pytest.python_api import RaisesContext
 
 from fair_mango.dataset.dataset import (
     Dataset,
@@ -43,7 +44,7 @@ dataset5 = Dataset(
 def test_check_column_existence_in_df(
     df: pd.DataFrame,
     columns: Sequence,
-    expected_result: None | RaisesContext,
+    expected_result: None | AbstractContextManager,
 ):
     if expected_result is not None:
         with expected_result:
@@ -66,7 +67,7 @@ def test_check_column_existence_in_df(
 def test_check_real_and_predicted_target_match(
     real_target: Sequence[str],
     predicted_target: Sequence[str],
-    expected_result: None | RaisesContext,
+    expected_result: None | AbstractContextManager,
 ):
     if expected_result is not None:
         with expected_result:
@@ -138,7 +139,7 @@ def test_dataset_init(
     predicted_target: Sequence[str],
     positive_target: Sequence[int | float | str | bool] | None,
     group_count: Sequence[int],
-    expected_result: None | RaisesContext,
+    expected_result: None | AbstractContextManager,
 ):
     if expected_result is None:
         dataset = Dataset(df, sensitive, real_target, predicted_target, positive_target)
@@ -148,7 +149,7 @@ def test_dataset_init(
         if "ChestPainType" in dataset.groups:
             for val in dataset.groups["ChestPainType"].unique():
                 assert val in ["ASY", "NAP", "ATA", "TA"]
-        assert (dataset.groups["Count"].values == group_count).all()
+        assert np.all(dataset.groups["Count"].values == group_count)
     else:
         with expected_result:
             Dataset(df, sensitive, real_target, predicted_target, positive_target)
@@ -213,15 +214,15 @@ def test_get_data_for_one_group(
 ):
     result = dataset.get_data_for_one_group(group)
     assert isinstance(result, pd.DataFrame)
-    assert (result[dataset.sensitive].nunique().values == 1).all()
+    assert np.all(result[dataset.sensitive].nunique().values == 1)
     assert result.shape == expected_data_shape
 
 
 @pytest.mark.parametrize(
     "dataset, sensitive_groups, expected_data_type, expected_data_shape",
     [
-        (dataset1, [["M"], ["F"]], pd.Series, [(725,), (193,)]),
-        (dataset2, [["M"], ["F"]], pd.Series, [(725,), (193,)]),
+        (dataset1, [["M"], ["F"]], pd.DataFrame, [(725, 1), (193, 1)]),
+        (dataset2, [["M"], ["F"]], pd.DataFrame, [(725, 1), (193, 1)]),
         (
             dataset3,
             [
@@ -234,8 +235,8 @@ def test_get_data_for_one_group(
                 ["M", "TA"],
                 ["F", "TA"],
             ],
-            pd.Series,
-            [(426,), (150,), (113,), (70,), (60,), (53,), (36,), (10,)],
+            pd.DataFrame,
+            [(426, 1), (150, 1), (113, 1), (70, 1), (60, 1), (53, 1), (36, 1), (10, 1)],
         ),
         (dataset4, [["M"], ["F"]], pd.DataFrame, [(725, 2), (193, 2)]),
         (dataset5, [["M"], ["F"]], pd.DataFrame, [(725, 2), (193, 2)]),
@@ -244,7 +245,7 @@ def test_get_data_for_one_group(
 def test_get_real_target_for_all_groups(
     dataset: Dataset,
     sensitive_groups: Sequence,
-    expected_data_type: pd.Series | pd.DataFrame,
+    expected_data_type: type[pd.DataFrame],
     expected_data_shape: Sequence,
 ):
     results = dataset.get_real_target_for_all_groups()
@@ -263,11 +264,11 @@ def test_get_real_target_for_all_groups(
         (
             dataset1,
             [["M"], ["F"]],
-            pd.Series,
-            [(725,), (193,)],
+            pd.DataFrame,
+            [(725, 1), (193, 1)],
             pytest.raises(ValueError),
         ),
-        (dataset2, [["M"], ["F"]], pd.Series, [(725,), (193,)], None),
+        (dataset2, [["M"], ["F"]], pd.DataFrame, [(725, 1), (193, 1)], None),
         (
             dataset3,
             [
@@ -280,8 +281,8 @@ def test_get_real_target_for_all_groups(
                 ["M", "TA"],
                 ["F", "TA"],
             ],
-            pd.Series,
-            [(426,), (150,), (113,), (70,), (60,), (53,), (36,), (10,)],
+            pd.DataFrame,
+            [(426, 1), (150, 1), (113, 1), (70, 1), (60, 1), (53, 1), (36, 1), (10, 1)],
             None,
         ),
         (
@@ -297,9 +298,9 @@ def test_get_real_target_for_all_groups(
 def test_get_predicted_target_for_all_groups(
     dataset: Dataset,
     sensitive_groups: Sequence,
-    expected_data_type: pd.Series | pd.DataFrame,
+    expected_data_type: type[pd.DataFrame],
     expected_data_shape: Sequence,
-    exception: RaisesContext | None,
+    exception: None | AbstractContextManager,
 ):
     if exception is None:
         results = dataset.get_predicted_target_for_all_groups()
@@ -318,16 +319,16 @@ def test_get_predicted_target_for_all_groups(
 @pytest.mark.parametrize(
     "dataset, sensitive_groups, expected_data_type, expected_data_shape",
     [
-        (dataset1, ["M"], pd.Series, (725,)),
+        (dataset1, ["M"], pd.DataFrame, (725, 1)),
         (dataset4, "F", pd.DataFrame, (193, 2)),
-        (dataset3, ["M", "ASY"], pd.Series, (426,)),
-        (dataset3, ["F", "ASY"], pd.Series, (70,)),
+        (dataset3, ["M", "ASY"], pd.DataFrame, (426, 1)),
+        (dataset3, ["F", "ASY"], pd.DataFrame, (70, 1)),
     ],
 )
 def test_get_real_target_for_one_group(
     dataset: Dataset,
     sensitive_groups: Sequence,
-    expected_data_type: pd.Series | pd.DataFrame,
+    expected_data_type: type[pd.DataFrame],
     expected_data_shape: Sequence,
 ):
     result = dataset.get_real_target_for_one_group(sensitive_groups)
@@ -338,19 +339,19 @@ def test_get_real_target_for_one_group(
 @pytest.mark.parametrize(
     "dataset, sensitive_groups, expected_data_type, expected_data_shape, exception",
     [
-        (dataset1, ["M"], pd.Series, (725,), pytest.raises(ValueError)),
+        (dataset1, ["M"], pd.DataFrame, (725, 1), pytest.raises(ValueError)),
         (dataset4, "F", pd.DataFrame, (193, 2), pytest.raises(ValueError)),
-        (dataset3, ["M", "ASY"], pd.Series, (426,), None),
-        (dataset3, ["F", "ASY"], pd.Series, (70,), None),
+        (dataset3, ["M", "ASY"], pd.DataFrame, (426, 1), None),
+        (dataset3, ["F", "ASY"], pd.DataFrame, (70, 1), None),
         (dataset5, "F", pd.DataFrame, (193, 2), None),
     ],
 )
 def test_get_predicted_target_for_one_group(
     dataset: Dataset,
     sensitive_groups: Sequence,
-    expected_data_type: pd.Series | pd.DataFrame,
+    expected_data_type: type[pd.DataFrame],
     expected_data_shape: Sequence,
-    exception: RaisesContext | None,
+    exception: None | AbstractContextManager,
 ):
     if exception is None:
         result = dataset.get_predicted_target_for_one_group(sensitive_groups)
@@ -375,7 +376,7 @@ def test_validate_columns(
     sensitive: Sequence[str],
     real_target: Sequence[str],
     predicted_target: Sequence[str] | None,
-    expected_result: None | RaisesContext,
+    expected_result: None | AbstractContextManager,
 ):
     if expected_result is not None:
         with expected_result:

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -1,6 +1,7 @@
+from contextlib import AbstractContextManager
+
 import pandas as pd
 import pytest
-from _pytest.python_api import RaisesContext
 
 from fair_mango.dataset.dataset import Dataset
 from fair_mango.metrics.base import encode_target, is_binary
@@ -55,7 +56,7 @@ def test_is_binary(y: pd.Series | pd.DataFrame, expected_result: bool):
     ],
 )
 def test_encode_target(
-    data: Dataset, ind: int, col: str, expected_result: None | RaisesContext
+    data: Dataset, ind: int, col: str, expected_result: None | AbstractContextManager
 ):
     if expected_result is None:
         encode_target(data, ind, col)

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
 
 import numpy as np
 import pandas as pd
 import pytest
-from _pytest.python_api import RaisesContext
 from sklearn.metrics import (
     accuracy_score,
     balanced_accuracy_score,
@@ -128,7 +128,7 @@ def test_selectionrate(
     data: Dataset,
     use_y_true: bool,
     expected_groups: Sequence[str],
-    expected_result: Sequence[float] | RaisesContext,
+    expected_result: Sequence[float] | AbstractContextManager,
 ):
     if isinstance(expected_result, Sequence):
         sr = SelectionRate(data, use_y_true)
@@ -237,7 +237,7 @@ confusionmatrix_expected_result_6 = [
 def test_confusionmatrix(
     data: Dataset,
     metrics: dict[str, Callable] | Sequence[Callable] | None,
-    expected_result: Sequence[dict[str, Sequence]] | RaisesContext,
+    expected_result: Sequence[dict[str, Sequence]] | AbstractContextManager,
 ):
     if isinstance(expected_result, Sequence):
         cf = ConfusionMatrix(data, metrics)
@@ -337,44 +337,36 @@ dpd_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, label, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, label, threshold, expected_result",
     [
-        (dataset2, "dpd", None, None, None, 0.3, dpd_expected_result_2),
+        (dataset2, "dpd", 0.3, dpd_expected_result_2),
         (
-            df,
+            Dataset(
+                df,
+                ["Sex", "ChestPainType"],
+                ["HeartDisease"],
+                ["HeartDiseasePred"],
+            ),
             "demographic_parity_difference",
-            ["Sex", "ChestPainType"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
             0.1,
             dpd_expected_result_3,
         ),
         (
             dataset6,
             "demographic_parity_difference",
-            None,
-            None,
-            None,
             0.45,
             dpd_expected_result_6,
         ),
     ],
 )
 def test_demographic_parity_difference(
-    data: Dataset | pd.DataFrame,
+    data: Dataset,
     label: str,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
     threshold: float,
     expected_result: Sequence[dict[str, dict]],
 ):
-    if isinstance(data, Dataset):
-        dpd = DemographicParityDifference(data, label)
-    else:
-        dpd = DemographicParityDifference(
-            data, label, sensitive, real_target, predicted_target
-        )
+    dpd = DemographicParityDifference(data, label)
+
     result = dpd.summary()
     assert result == expected_result[0]
     ranking = dpd.rank()
@@ -473,33 +465,24 @@ dpr_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, label, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, label, threshold, expected_result",
     [
-        (dataset1, "dpr", None, None, None, 1.2, dpr_expected_result_1),
+        (dataset1, "dpr", 1.2, dpr_expected_result_1),
         (
-            df,
+            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
             "dpr",
-            ["Sex"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
             0.4,
             dpr_expected_result_2,
         ),
         (
             dataset3,
             "demographic_parity_ratio",
-            None,
-            None,
-            None,
             0.8,
             dpr_expected_result_3,
         ),
         (
             dataset6,
             "demographic_parity_ratio",
-            None,
-            None,
-            None,
             0.3,
             dpr_expected_result_6,
         ),
@@ -508,18 +491,10 @@ dpr_expected_result_6 = [
 def test_demographic_parity_ratio(
     data: Dataset,
     label: str,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
     threshold: float,
     expected_result: Sequence[dict[str, dict]],
 ):
-    if isinstance(data, Dataset):
-        dpr = DemographicParityRatio(data, label)
-    else:
-        dpr = DemographicParityRatio(
-            data, label, sensitive, real_target, predicted_target
-        )
+    dpr = DemographicParityRatio(data, label)
     result = dpr.summary()
     assert result == expected_result[0]
     ranking = dpr.rank()
@@ -609,47 +584,36 @@ did_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, label, sensitive, real_target, predicted_target, positive_target, threshold, expected_result",
+    "data, label, threshold, expected_result",
     [
-        (dataset2, "did", None, None, None, None, 0.3, did_expected_result_2),
+        (dataset2, "did", 0.3, did_expected_result_2),
         (
             dataset3,
             "disparate_impact_difference",
-            None,
-            None,
-            None,
-            None,
             -0.2,
             did_expected_result_3,
         ),
         (
-            df,
+            Dataset(
+                df,
+                ["Sex", "ChestPainType"],
+                ["HeartDisease", "ExerciseAngina"],
+                ["HeartDiseasePred", "ExerciseAnginaPred"],
+                [1, "Y"],
+            ),
             "disparate_impact_difference",
-            ["Sex", "ChestPainType"],
-            ["HeartDisease", "ExerciseAngina"],
-            ["HeartDiseasePred", "ExerciseAnginaPred"],
-            [1, "Y"],
             0.45,
             did_expected_result_6,
         ),
     ],
 )
 def test_disparate_impact_difference(
-    data: Dataset | pd.DataFrame,
+    data: Dataset,
     label: str,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
-    positive_target: Sequence[int | float | str | bool] | None,
     threshold: float,
     expected_result: Sequence[dict[str, dict]],
 ):
-    if isinstance(data, Dataset):
-        did = DisparateImpactDifference(data, label)
-    else:
-        did = DisparateImpactDifference(
-            data, label, sensitive, real_target, predicted_target, positive_target
-        )
+    did = DisparateImpactDifference(data, label)
 
     result = did.summary()
     assert result == expected_result[0]
@@ -740,62 +704,43 @@ dir_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, label, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, label, threshold, expected_result",
     [
         (
             dataset1,
             "dir",
-            None,
-            None,
-            None,
             1.2,
             pytest.raises(ValueError),
         ),
         (
-            df,
+            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
             "dir",
-            ["Sex"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
             0.4,
             dir_expected_result_2,
         ),
         (
             dataset3,
             "disparate_impact_ratio",
-            None,
-            None,
-            None,
             0.8,
             dir_expected_result_3,
         ),
         (
             dataset6,
             "disparate_impact_ratio",
-            None,
-            None,
-            None,
             0.3,
             dir_expected_result_6,
         ),
     ],
 )
 def test_disparate_impact_ratio(
-    data: Dataset | pd.DataFrame,
+    data: Dataset,
     label: str,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
     threshold: float,
-    expected_result: Sequence[dict[str, dict]] | RaisesContext,
+    expected_result: Sequence[dict[str, dict]] | AbstractContextManager,
 ):
     if isinstance(expected_result, Sequence):
-        if isinstance(data, Dataset):
-            dira = DisparateImpactRatio(data, label)
-        else:
-            dira = DisparateImpactRatio(
-                data, label, sensitive, real_target, predicted_target
-            )
+        dira = DisparateImpactRatio(data, label)
+
         result = dira.summary()
         assert result == expected_result[0]
         ranking = dira.rank()
@@ -804,12 +749,7 @@ def test_disparate_impact_ratio(
         assert is_biased == expected_result[2]
     else:
         with expected_result:
-            if isinstance(data, Dataset):
-                dira = DisparateImpactRatio(data, label)
-            else:
-                dira = DisparateImpactRatio(
-                    data, label, sensitive, real_target, predicted_target
-                )
+            dira = DisparateImpactRatio(data, label)
             dira.summary()
 
 
@@ -890,44 +830,35 @@ eod_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, label, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, label, threshold, expected_result",
     [
-        (dataset2, "eod", None, None, None, 0.1, eod_expected_result_2),
+        (dataset2, "eod", 0.1, eod_expected_result_2),
         (
-            df,
+            Dataset(
+                df,
+                ["Sex", "ChestPainType"],
+                ["HeartDisease"],
+                ["HeartDiseasePred"],
+            ),
             "equal_opportunity_difference",
-            ["Sex", "ChestPainType"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
             0.2,
             eod_expected_result_3,
         ),
         (
             dataset6,
             "equal_opportunity_difference",
-            None,
-            None,
-            None,
             0.2,
             eod_expected_result_6,
         ),
     ],
 )
 def test_equal_opportunity_difference(
-    data: Dataset | pd.DataFrame,
+    data: Dataset,
     label: str,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
     threshold: float,
     expected_result: Sequence[dict[str, dict]],
 ):
-    if isinstance(data, Dataset):
-        eod = EqualOpportunityDifference(data, label)
-    else:
-        eod = EqualOpportunityDifference(
-            data, label, sensitive, real_target, predicted_target
-        )
+    eod = EqualOpportunityDifference(data, label)
     result = eod.summary()
     assert result == expected_result[0]
     rankings = eod.rank()
@@ -1019,62 +950,42 @@ eor_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, label, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, label, threshold, expected_result",
     [
         (
             dataset1,
             "eor",
-            None,
-            None,
-            None,
             1.2,
             pytest.raises(ValueError),
         ),
         (
-            df,
+            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
             "eor",
-            ["Sex"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
             0.4,
             eor_expected_result_2,
         ),
         (
             dataset3,
             "equal_opportunity_ratio",
-            None,
-            None,
-            None,
             0.8,
             eor_expected_result_3,
         ),
         (
             dataset6,
             "equal_opportunity_ratio",
-            None,
-            None,
-            None,
             0.9,
             eor_expected_result_6,
         ),
     ],
 )
 def test_equal_opportuinity_ratio(
-    data: pd.DataFrame | Dataset,
+    data: Dataset,
     label: str,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
     threshold: float,
-    expected_result: Sequence[dict[str, dict]] | RaisesContext,
+    expected_result: Sequence[dict[str, dict]] | AbstractContextManager,
 ):
     if isinstance(expected_result, Sequence):
-        if isinstance(data, Dataset):
-            eor = EqualOpportunityRatio(data, label)
-        else:
-            eor = EqualOpportunityRatio(
-                data, label, sensitive, real_target, predicted_target
-            )
+        eor = EqualOpportunityRatio(data, label)
         result = eor.summary()
         assert result == expected_result[0]
         rankings = eor.rank()
@@ -1089,12 +1000,7 @@ def test_equal_opportuinity_ratio(
         assert is_biased == expected_result[2]
     else:
         with expected_result:
-            if isinstance(data, Dataset):
-                eor = EqualOpportunityRatio(data, label)
-            else:
-                eor = EqualOpportunityRatio(
-                    data, label, sensitive, real_target, predicted_target
-                )
+            eor = EqualOpportunityRatio(data, label)
             eor.summary()
 
 
@@ -1215,24 +1121,16 @@ performancemetrics_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, metrics, sensitive, real_target, predicted_target, positive_target, expected_result",
+    "data, metrics, expected_result",
     [
-        (dataset1, None, None, None, None, None, pytest.raises(ValueError)),
+        (dataset1, None, pytest.raises(ValueError)),
         (
             dataset2,
             {"sensitive": f1_score},
-            None,
-            None,
-            None,
-            None,
             pytest.raises(KeyError),
         ),
         (
-            df,
-            None,
-            ["Sex"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
+            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
             None,
             performancemetrics_expected_result_2,
         ),
@@ -1242,39 +1140,22 @@ performancemetrics_expected_result_6 = [
                 "acc": accuracy_score,
                 "balanced_acc": balanced_accuracy_score,
             },
-            None,
-            None,
-            None,
-            None,
             performancemetrics_expected_result_3,
         ),
         (
             dataset6,
             [precision_score, recall_score, f1_score],
-            None,
-            None,
-            None,
-            None,
             performancemetrics_expected_result_6,
         ),
     ],
 )
 def test_performancemetrics(
-    data: pd.DataFrame | Dataset,
+    data: Dataset,
     metrics: dict[str, Callable] | None,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
-    positive_target: Sequence[int | float | str | bool] | None,
-    expected_result: Sequence[dict[str, Sequence]] | RaisesContext,
+    expected_result: Sequence[dict[str, Sequence]] | AbstractContextManager,
 ):
     if isinstance(expected_result, Sequence):
-        if isinstance(data, Dataset):
-            pm = PerformanceMetric(data, metrics)
-        else:
-            pm = PerformanceMetric(
-                data, metrics, sensitive, real_target, predicted_target, positive_target
-            )
+        pm = PerformanceMetric(data, metrics)
         result = pm()
         assert result[0] == pm.data.real_target
         for i, res in enumerate(result[1]):
@@ -1290,7 +1171,8 @@ def test_performancemetrics(
     else:
         with expected_result:
             pm = PerformanceMetric(
-                data, metrics, sensitive, real_target, predicted_target, positive_target
+                data,
+                metrics,
             )
             pm()
 
@@ -1372,39 +1254,29 @@ eod_expected_result_6 = [
 
 
 @pytest.mark.parametrize(
-    "data, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, threshold, expected_result",
     [
-        (dataset2, None, None, None, 0.1, eod_expected_result_2),
+        (dataset2, 0.1, eod_expected_result_2),
         (
-            df,
-            ["Sex", "ChestPainType"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
+            Dataset(
+                df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"]
+            ),
             0.2,
             eod_expected_result_3,
         ),
         (
             dataset6,
-            None,
-            None,
-            None,
             0.2,
             eod_expected_result_6,
         ),
     ],
 )
 def test_equalised_odds_difference(
-    data: Dataset | pd.DataFrame,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
+    data: Dataset,
     threshold: float,
     expected_result: Sequence[dict[str, dict]],
 ):
-    if isinstance(data, Dataset):
-        eod = EqualisedOddsDifference(data)
-    else:
-        eod = EqualisedOddsDifference(data, sensitive, real_target, predicted_target)
+    eod = EqualisedOddsDifference(data)
     result = eod.summary()
     assert result == expected_result[0]
     rankings = eod.rank()
@@ -1457,29 +1329,20 @@ eor_expected_result_3 = [
 
 
 @pytest.mark.parametrize(
-    "data, sensitive, real_target, predicted_target, threshold, expected_result",
+    "data, threshold, expected_result",
     [
         (
             dataset1,
-            None,
-            None,
-            None,
             1.2,
             pytest.raises(ValueError),
         ),
         (
-            df,
-            ["Sex"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
+            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
             0.4,
             eor_expected_result_2,
         ),
         (
             dataset3,
-            None,
-            None,
-            None,
             0.8,
             eor_expected_result_3,
         ),
@@ -1487,17 +1350,11 @@ eor_expected_result_3 = [
 )
 def test_equalised_odds_ratio(
     data: Dataset,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
     threshold: float,
-    expected_result: Sequence[dict[str, dict]] | RaisesContext,
+    expected_result: Sequence[dict[str, dict]] | AbstractContextManager,
 ):
     if isinstance(expected_result, Sequence):
-        if isinstance(data, Dataset):
-            eor = EqualisedOddsRatio(data)
-        else:
-            eor = EqualisedOddsRatio(data, sensitive, real_target, predicted_target)
+        eor = EqualisedOddsRatio(data)
         result = eor.summary()
         assert result == expected_result[0]
         rankings = eor.rank()
@@ -1512,8 +1369,5 @@ def test_equalised_odds_ratio(
         assert is_biased == expected_result[2]
     else:
         with expected_result:
-            if isinstance(data, Dataset):
-                eor = EqualisedOddsRatio(data)
-            else:
-                eor = EqualisedOddsRatio(data, sensitive, real_target, predicted_target)
+            eor = EqualisedOddsRatio(data)
             eor.summary()

--- a/tests/metrics/test_superset.py
+++ b/tests/metrics/test_superset.py
@@ -1,9 +1,9 @@
 from collections.abc import Sequence
+from contextlib import AbstractContextManager
 
 import numpy as np
 import pandas as pd
 import pytest
-from _pytest.python_api import RaisesContext
 
 from fair_mango.dataset.dataset import Dataset
 from fair_mango.metrics.metrics import (
@@ -133,30 +133,23 @@ super_set_fairness_metrics_expected_result_3 = [
 
 
 @pytest.mark.parametrize(
-    "metric, data, sensitive, real_target, predicted_target, expected_results",
+    "metric, data, expected_results",
     [
         (
             DemographicParityDifference,
             dataset1,
-            None,
-            None,
-            None,
             super_set_fairness_metrics_expected_result_1,
         ),
         (
             DisparateImpactRatio,
-            df,
-            ["Sex", "ChestPainType"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
+            Dataset(
+                df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"]
+            ),
             super_set_fairness_metrics_expected_result_2,
         ),
         (
             EqualisedOddsDifference,
             dataset3,
-            None,
-            None,
-            None,
             super_set_fairness_metrics_expected_result_3,
         ),
     ],
@@ -174,25 +167,13 @@ def test_super_set_fairness_metrics(
         | type[FalsePositiveRateDifference]
         | type[FalsePositiveRateRatio]
     ),
-    data: pd.DataFrame | Dataset,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
-    expected_results: Sequence[dict[str, dict]] | RaisesContext,
+    data: Dataset,
+    expected_results: Sequence[dict[str, dict]] | AbstractContextManager,
 ):
-    if isinstance(data, pd.DataFrame):
-        super_set_fairness_metrics = SupersetFairnessMetrics(  # type: ignore[call-overload]
-            metric,
-            data,
-            sensitive,
-            real_target,
-            predicted_target,
-        )
-    else:
-        super_set_fairness_metrics = SupersetFairnessMetrics(
-            metric,
-            data,
-        )
+    super_set_fairness_metrics = SupersetFairnessMetrics(
+        metric,
+        data,
+    )
     results = super_set_fairness_metrics.rank()
 
     assert results == expected_results
@@ -239,50 +220,30 @@ super_set_performance_metrics_expected_result_2 = [
 
 
 @pytest.mark.parametrize(
-    "data, sensitive, real_target, predicted_target, expected_results",
+    "data, expected_results",
     [
         (
             dataset1,
-            None,
-            None,
-            None,
             pytest.raises(ValueError),
         ),
         (
             dataset2,
-            None,
-            None,
-            None,
             super_set_performance_metrics_expected_result_2,
         ),
         (
-            df,
-            ["Sex"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
+            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
             super_set_performance_metrics_expected_result_2,
         ),
     ],
 )
 def test_super_set_performance_metrics(
-    data: pd.DataFrame | Dataset,
-    sensitive: Sequence[str] | None,
-    real_target: Sequence[str] | None,
-    predicted_target: Sequence[str] | None,
-    expected_results: list[dict] | RaisesContext,
+    data: Dataset,
+    expected_results: list[dict] | AbstractContextManager,
 ):
     if isinstance(expected_results, list):
-        if isinstance(data, pd.DataFrame):
-            super_set_performance_metrics = SupersetPerformanceMetrics(  # type: ignore[call-overload]
-                data,
-                sensitive,
-                real_target,
-                predicted_target,
-            )
-        else:
-            super_set_performance_metrics = SupersetPerformanceMetrics(
-                data,
-            )
+        super_set_performance_metrics = SupersetPerformanceMetrics(
+            data,
+        )
         results = super_set_performance_metrics.evaluate()
         for result, expected_result in zip(results, expected_results):
             for result_values, expected_result_values in zip(
@@ -297,14 +258,6 @@ def test_super_set_performance_metrics(
                         assert value == expected_value
     else:
         with expected_results:
-            if isinstance(data, pd.DataFrame):
-                SupersetPerformanceMetrics(  # type: ignore[call-overload]
-                    data,
-                    sensitive,
-                    real_target,
-                    predicted_target,
-                ).evaluate()
-            else:
-                SupersetPerformanceMetrics(
-                    data,
-                ).evaluate()
+            SupersetPerformanceMetrics(
+                data,
+            ).evaluate()


### PR DESCRIPTION
- Removed overloads that do not use our internal Dataset class. It will simplify the code and improve maintainability.

- Fixing type errors due to the removal of overloads that do not use our internat Dataset Class.

- Fixing test files to match with the new implementation

- Removing 2 .squeeze() method that was causing types error, and fix the error that was thus cause by this removal.

- Fixing some part of the docstring but there is still a lot to do with it