### PR TITLE
Refactor Dataset initialization and metric calculations to remove multitargets

### DIFF
--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -166,14 +166,14 @@ class Dataset:
     sensitive : Sequence[str]
         Sequence of column names corresponding to sensitive features
         (Ex: gender, race...).
-    real_target : Sequence[str]
-        Sequence of column names corresponding to the real target
-        (true labels).
-    predicted_target : Sequence[str], optional
-        Sequence of column names corresponding to the predicted target,
+    real_target : str
+        The column name corresponding to the real target
+        (true label).
+    predicted_target : str, optional
+        The column name corresponding to the predicted target,
         by default None.
-    positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided target,
+    positive_target : int  |  float  |  str  |  bool | None, optional
+        The positive label corresponding to the provided target,
         by default None.
     """
 
@@ -714,7 +714,7 @@ class Dataset:
 
         Parameters
         ----------
-        sensitive : Sequence[str]
+        sensitive_group : Sequence[str]
             Sequence of sensitive values must be in the same order as `sensitive`
             attribute, and so `sensitive_group` must be the same length as
             `sensitive`. For instance, if your `sensitive` attribute were

--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 
 
@@ -27,33 +26,10 @@ def check_column_existence_in_df(df: pd.DataFrame, columns: Sequence[str]) -> No
             )
 
 
-def check_real_and_predicted_target_match(
-    real_target: Sequence[str], predicted_target: Sequence[str]
-) -> None:
-    """Check that the number of real targets and number of predicted targets
-    match.
-
-    Parameters
-    ----------
-    real_target : Sequence[str]
-        Sequence of column names corresponding to the real targets
-        (true labels).
-    predicted_target : Sequence[str]
-        Sequence of column names corresponding to the predicted targets.
-
-    Raises
-    ------
-    ValueError
-        If the number of real targets and predicted targets does not match.
-    """
-    if len(real_target) != len(predicted_target):
-        raise ValueError("real_target and predicted_target does not match")
-
-
 def validate_columns(
     sensitive: Sequence[str],
-    real_target: Sequence[str],
-    predicted_target: Sequence[str] | None = None,
+    real_target: str,
+    predicted_target: str | None = None,
 ) -> None:
     """Make sure that the columns provided as parameters are different.
     A column cannot be a sensitive column and a target at the same time.
@@ -65,10 +41,10 @@ def validate_columns(
         Sequence of column names corresponding to sensitive features
         (Ex: gender, race...).
     real_target : Sequence[str]
-        Sequence of column names corresponding to the real targets
+        Sequence of column names corresponding to the real target
         (true labels). Every target will be processed independently.
     predicted_target : Sequence[str], optional
-        Sequence of column names corresponding to the predicted targets,
+        Sequence of column names corresponding to the predicted target,
         by default None.
 
     Raises
@@ -76,11 +52,17 @@ def validate_columns(
     AttributeError
         If the same column is assigned to different parameters at the same time.
     """
-    overlap = set(sensitive).intersection(real_target)
+    sensitive_set = set(sensitive)
+
+    overlap = set()
+    if real_target in sensitive_set:
+        overlap.add(real_target)
 
     if predicted_target is not None:
-        overlap.update(set(sensitive).intersection(predicted_target))
-        overlap.update(set(real_target).intersection(predicted_target))
+        if predicted_target in sensitive_set:
+            overlap.add(predicted_target)
+        if predicted_target == real_target:
+            overlap.add(predicted_target)
 
     if overlap:
         raise AttributeError(
@@ -107,6 +89,67 @@ def convert_to_list(variable: Sequence[str] | str) -> Sequence[str]:
         return variable
 
 
+def type_verification(
+    df: pd.DataFrame,
+    sensitive: Sequence[str] | str,
+    real_target: str,
+    predicted_target: str | None = None,
+    positive_target: int | float | str | bool | None = None,
+):
+    """
+    Verifies the types of the input arguments.
+
+    Parameters:
+    ------------
+        df: A pandas DataFrame.
+        sensitive: A sequence of strings or a single string.
+        real_target: A string.
+        predicted_target: A string or None.
+        positive_target: An int, float, string, bool, or None.
+
+    Raises:
+        TypeError: If any of the input arguments have the wrong type.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(
+            f"df must be a pandas DataFrame, "
+            f"but got an object of type {type(df).__name__}"
+        )
+
+    if not isinstance(sensitive, str):
+        if isinstance(sensitive, Sequence):
+            if not all(isinstance(x, str) for x in sensitive):
+                raise TypeError(
+                    "sensitive must be a Sequence of strings or a string, "
+                    "but got a Sequence with non-string elements"
+                )
+        else:
+            raise TypeError(
+                f"sensitive must be a Sequence of strings or a string, "
+                f"but got an object of type {type(sensitive).__name__}"
+            )
+
+    if not isinstance(real_target, str):
+        raise TypeError(
+            f"real_target must be a string, "
+            f"but got an object of type {type(real_target).__name__}"
+        )
+
+    if predicted_target is not None and not isinstance(predicted_target, str):
+        raise TypeError(
+            f"predicted_target must be a string or None, "
+            f"but got an object of type {type(predicted_target).__name__}"
+        )
+
+    if positive_target is not None and not isinstance(
+        positive_target, (int, float, str, bool)
+    ):
+        raise TypeError(
+            f"positive_target must be an int, float, string, bool, or None, "
+            f"but got an object of type {type(positive_target).__name__}"
+        )
+
+
 class Dataset:
     """A class for handling datasets with sensitive attributes and target
     variables.
@@ -124,36 +167,34 @@ class Dataset:
         Sequence of column names corresponding to sensitive features
         (Ex: gender, race...).
     real_target : Sequence[str]
-        Sequence of column names corresponding to the real targets
+        Sequence of column names corresponding to the real target
         (true labels).
     predicted_target : Sequence[str], optional
-        Sequence of column names corresponding to the predicted targets,
+        Sequence of column names corresponding to the predicted target,
         by default None.
     positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
+        Sequence of the positive labels corresponding to the provided target,
         by default None.
     """
 
     def __init__(
         self,
         df: pd.DataFrame,
-        sensitive: Sequence[str],
-        real_target: Sequence[str],
-        predicted_target: Sequence[str] | None = None,
-        positive_target: Sequence[int | float | str | bool] | None = None,
+        sensitive: Sequence[str] | str,
+        real_target: str,
+        predicted_target: str | None = None,
+        positive_target: int | float | str | bool | None = None,
     ):
+        type_verification(df, sensitive, real_target, predicted_target, positive_target)
         self.sensitive = convert_to_list(sensitive)
         check_column_existence_in_df(df, self.sensitive)
-        self.real_target = convert_to_list(real_target)
-        check_column_existence_in_df(df, self.real_target)
+        self.real_target = real_target
+        check_column_existence_in_df(df, [self.real_target])
         if predicted_target is not None:
-            self.predicted_target = convert_to_list(predicted_target)
-            check_column_existence_in_df(df, self.predicted_target)
-            check_real_and_predicted_target_match(
-                self.real_target, self.predicted_target
-            )
+            self.predicted_target = predicted_target
+            check_column_existence_in_df(df, [self.predicted_target])
         else:
-            self.predicted_target = []
+            self.predicted_target = None  # type: ignore
         validate_columns(self.sensitive, self.real_target, self.predicted_target)
         self.df = df.copy()
         self.shape = df.shape
@@ -470,7 +511,7 @@ class Dataset:
 
     def get_real_target_for_one_group(
         self, sensitive_group: Sequence[str]
-    ) -> pd.DataFrame:
+    ) -> pd.Series:
         """Retrieve the real target corresponding to a specific sensitive
         group present in the sensitive features.
 
@@ -537,19 +578,18 @@ class Dataset:
         """
         result = None
         if self.groups_real_target is None:
-            result = self.df
+            filtered_df = self.df
             for i in range(len(sensitive_group)):
-                result = result[result[self.sensitive[i]].isin(sensitive_group)]
-            result = result[self.real_target]
+                filtered_df = filtered_df[
+                    filtered_df[self.sensitive[i]].isin(sensitive_group)
+                ]
+            result = filtered_df[self.real_target]
         else:
             for item in self.groups_real_target:
                 if (item["sensitive"] == sensitive_group).all() or (
                     item["sensitive"] == sensitive_group[::-1]
                 ).all():
-                    if isinstance(item["data"], (np.ndarray, pd.Series)):
-                        result = pd.DataFrame(item["data"])
-                    else:
-                        result = item["data"]
+                    result = item["data"]
         if result is None:
             raise (
                 ValueError(f"{sensitive_group} group does not exist in the dataframe")
@@ -642,7 +682,7 @@ class Dataset:
             }
         ]
         """
-        if self.predicted_target == []:
+        if self.predicted_target is None:
             raise ValueError(
                 "predicted_target parameter is required when creating the dataset"
             )
@@ -658,7 +698,7 @@ class Dataset:
 
     def get_predicted_target_for_one_group(
         self, sensitive_group: Sequence[str]
-    ) -> pd.DataFrame:
+    ) -> pd.Series:
         """Retrieve the predicted target corresponding to a specific sensitive
         group present in the sensitive features.
 
@@ -723,25 +763,24 @@ class Dataset:
         3           0                yes
         4           0                yes
         """
-        if self.predicted_target == []:
+        if self.predicted_target is None:
             raise ValueError(
                 "predicted_target parameter is required when creating the dataset"
             )
         result = None
         if self.groups_predicted_target is None:
-            result = self.df
+            filtered_df = self.df
             for i in range(len(sensitive_group)):
-                result = result[result[self.sensitive[i]].isin(sensitive_group)]
-            result = result[self.predicted_target]
+                filtered_df = filtered_df[
+                    filtered_df[self.sensitive[i]].isin(sensitive_group)
+                ]
+            result = filtered_df[self.predicted_target]
         else:
             for item in self.groups_predicted_target:
                 if (item["sensitive"] == sensitive_group).all() or (
                     item["sensitive"] == sensitive_group[::-1]
                 ).all():
-                    if isinstance(item["data"], (np.ndarray, pd.Series)):
-                        result = pd.DataFrame(item["data"])
-                    else:
-                        result = item["data"]
+                    result = item["data"]
         if result is None:
             raise (
                 ValueError(f"{sensitive_group} group does not exist in the dataframe")

--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -89,65 +89,30 @@ def convert_to_list(variable: Sequence[str] | str) -> Sequence[str]:
         return variable
 
 
-def type_verification(
-    df: pd.DataFrame,
-    sensitive: Sequence[str] | str,
-    real_target: str,
-    predicted_target: str | None = None,
-    positive_target: int | float | str | bool | None = None,
-):
+def df_filtration(
+    df: pd.DataFrame, sensitive_group: Sequence[str], sensitive: Sequence[str]
+) -> pd.DataFrame:
+    """Filters a DataFrame to only take the sensitive groups
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        df of the dataset
+
+    sensitive : Sequence[str]
+            Sequence of sensitive values must be in the same order as `sensitive`
+            attribute, and so `sensitive_group` must be the same length as
+            `sensitive`. For instance, if your `sensitive` attributes were
+            `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
+
+    Returns
+    -------
+    pd.Dataframe
     """
-    Verifies the types of the input arguments.
-
-    Parameters:
-    ------------
-        df: A pandas DataFrame.
-        sensitive: A sequence of strings or a single string.
-        real_target: A string.
-        predicted_target: A string or None.
-        positive_target: An int, float, string, bool, or None.
-
-    Raises:
-        TypeError: If any of the input arguments have the wrong type.
-    """
-    if not isinstance(df, pd.DataFrame):
-        raise TypeError(
-            f"df must be a pandas DataFrame, "
-            f"but got an object of type {type(df).__name__}"
-        )
-
-    if not isinstance(sensitive, str):
-        if isinstance(sensitive, Sequence):
-            if not all(isinstance(x, str) for x in sensitive):
-                raise TypeError(
-                    "sensitive must be a Sequence of strings or a string, "
-                    "but got a Sequence with non-string elements"
-                )
-        else:
-            raise TypeError(
-                f"sensitive must be a Sequence of strings or a string, "
-                f"but got an object of type {type(sensitive).__name__}"
-            )
-
-    if not isinstance(real_target, str):
-        raise TypeError(
-            f"real_target must be a string, "
-            f"but got an object of type {type(real_target).__name__}"
-        )
-
-    if predicted_target is not None and not isinstance(predicted_target, str):
-        raise TypeError(
-            f"predicted_target must be a string or None, "
-            f"but got an object of type {type(predicted_target).__name__}"
-        )
-
-    if positive_target is not None and not isinstance(
-        positive_target, (int, float, str, bool)
-    ):
-        raise TypeError(
-            f"positive_target must be an int, float, string, bool, or None, "
-            f"but got an object of type {type(positive_target).__name__}"
-        )
+    mask = pd.Series(True, index=df.index)
+    for column, value in zip(sensitive, sensitive_group):
+        mask &= df[column] == value
+    return df[mask]
 
 
 class Dataset:
@@ -185,7 +150,6 @@ class Dataset:
         predicted_target: str | None = None,
         positive_target: int | float | str | bool | None = None,
     ):
-        type_verification(df, sensitive, real_target, predicted_target, positive_target)
         self.sensitive = convert_to_list(sensitive)
         check_column_existence_in_df(df, self.sensitive)
         self.real_target = real_target
@@ -194,7 +158,7 @@ class Dataset:
             self.predicted_target = predicted_target
             check_column_existence_in_df(df, [self.predicted_target])
         else:
-            self.predicted_target = None  # type: ignore
+            self.predicted_targe = None
         validate_columns(self.sensitive, self.real_target, self.predicted_target)
         self.df = df.copy()
         self.shape = df.shape
@@ -398,9 +362,7 @@ class Dataset:
         """
         result = None
         if self.groups_data == []:
-            result = self.df
-            for i in range(len(sensitive_group)):
-                result = result[result[self.sensitive[i]].isin(sensitive_group)]
+            result = df_filtration(self.df, sensitive_group, self.sensitive)
         else:
             for item in self.groups_data:
                 if (all(e1 in item["sensitive"] for e1 in sensitive_group)) and (
@@ -578,11 +540,7 @@ class Dataset:
         """
         result = None
         if self.groups_real_target is None:
-            filtered_df = self.df
-            for i in range(len(sensitive_group)):
-                filtered_df = filtered_df[
-                    filtered_df[self.sensitive[i]].isin(sensitive_group)
-                ]
+            filtered_df = df_filtration(self.df, sensitive_group, self.sensitive)
             result = filtered_df[self.real_target]
         else:
             for item in self.groups_real_target:
@@ -769,11 +727,7 @@ class Dataset:
             )
         result = None
         if self.groups_predicted_target is None:
-            filtered_df = self.df
-            for i in range(len(sensitive_group)):
-                filtered_df = filtered_df[
-                    filtered_df[self.sensitive[i]].isin(sensitive_group)
-                ]
+            filtered_df = df_filtration(self.df, sensitive_group, self.sensitive)
             result = filtered_df[self.predicted_target]
         else:
             for item in self.groups_predicted_target:

--- a/fair_mango/dataset/dataset.py
+++ b/fair_mango/dataset/dataset.py
@@ -100,17 +100,17 @@ def df_filtration(
         df of the dataset
 
     sensitive : Sequence[str]
-            Sequence of sensitive values must be in the same order as `sensitive`
-            attribute, and so `sensitive_group` must be the same length as
-            `sensitive`. For instance, if your `sensitive` attributes were
-            `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
+        Sequence of sensitive values must be in the same order as `sensitive`
+        attribute, and so `sensitive_group` must be the same length as
+        `sensitive`. For instance, if your `sensitive` attributes were
+        `["race", "gender"]`, you can pass `sensitive_group=["white", "male"]`.
 
     Returns
     -------
     pd.Dataframe
     """
     mask = pd.Series(True, index=df.index)
-    for column, value in zip(sensitive, sensitive_group):
+    for column, value in zip(sensitive, sensitive_group, strict=True):
         mask &= df[column] == value
     return df[mask]
 
@@ -154,11 +154,9 @@ class Dataset:
         check_column_existence_in_df(df, self.sensitive)
         self.real_target = real_target
         check_column_existence_in_df(df, [self.real_target])
-        if predicted_target is not None:
-            self.predicted_target = predicted_target
+        self.predicted_target = predicted_target
+        if self.predicted_target is not None:
             check_column_existence_in_df(df, [self.predicted_target])
-        else:
-            self.predicted_targe = None
         validate_columns(self.sensitive, self.real_target, self.predicted_target)
         self.df = df.copy()
         self.shape = df.shape

--- a/fair_mango/metrics/base.py
+++ b/fair_mango/metrics/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Hashable, Sequence
 from itertools import combinations
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -10,12 +10,12 @@ from numpy.typing import NDArray
 from fair_mango.dataset.dataset import Dataset
 
 
-def is_binary(y: pd.Series | pd.DataFrame) -> bool:
+def is_binary(y: pd.Series) -> bool:
     """Check if a data contains two unique values.
 
     Parameters
     ----------
-    y : pd.Series | pd.DataFrame
+    y : pd.Series
         Input data.
 
     Returns
@@ -23,16 +23,10 @@ def is_binary(y: pd.Series | pd.DataFrame) -> bool:
     bool
         True if data contains two unique values else False.
     """
-    if isinstance(y, pd.Series):
-        if y.nunique() == 2:
-            return True
-        else:
-            return False
+    if y.nunique() == 2:
+        return True
     else:
-        if (y.nunique() == 2).all():
-            return True
-        else:
-            return False
+        return False
 
 
 def encode_target(data: Dataset, col: str | Hashable) -> None:
@@ -166,7 +160,7 @@ class Metric(ABC):
     def __init__(self, data: Dataset) -> None:
         self.data = data
         self.predicted_target_by_group = []
-        y: Any = self.data.df[self.data.real_target]
+        y: pd.Series = self.data.df[self.data.real_target]
 
         if is_binary(y):
             if (np.unique(y) != [0, 1]).all():

--- a/fair_mango/metrics/base.py
+++ b/fair_mango/metrics/base.py
@@ -35,8 +35,8 @@ def is_binary(y: pd.Series | pd.DataFrame) -> bool:
             return False
 
 
-def encode_target(data: Dataset, ind: int, col: str | Hashable) -> None:
-    """encode targets as [0,1]
+def encode_target(data: Dataset, col: str | Hashable) -> None:
+    """encode target as [0,1]
 
     Parameters
     ----------
@@ -62,13 +62,13 @@ def encode_target(data: Dataset, ind: int, col: str | Hashable) -> None:
             "the dataset to solve this issue."
         )
     else:
-        if data.positive_target[ind] in data.df[col].unique():
-            mapping = {data.positive_target[ind]: 1}
+        if data.positive_target in data.df[col].unique():
+            mapping = {data.positive_target: 1}
             data.df[col] = data.df[col].map(mapping).fillna(0).astype(int)
         else:
             raise KeyError(
                 "Positive target value provided does not exist in the column. "
-                f"{data.positive_target[ind]} does not exist in column {col}: "
+                f"{data.positive_target} does not exist in column {col}: "
                 f"{data.df[col].unique()}"
             )
 
@@ -165,34 +165,19 @@ class Metric(ABC):
 
     def __init__(self, data: Dataset) -> None:
         self.data = data
-        self.predicted_targets_by_group = []
+        self.predicted_target_by_group = []
         y: Any = self.data.df[self.data.real_target]
-        if len(self.data.real_target) > 1:
-            y = y.squeeze()
+
         if is_binary(y):
-            if isinstance(y, pd.Series):
-                if (np.unique(y) != [0, 1]).all():
-                    encode_target(self.data, 0, y.name)
-            else:
-                for ind, col in enumerate(y.columns):
-                    if (np.unique(y[col]) != [0, 1]).all():
-                        encode_target(self.data, ind, col)
+            if (np.unique(y) != [0, 1]).all():
+                encode_target(self.data, y.name)
+            self.real_target_by_group = self.data.get_real_target_for_all_groups()
 
-            self.real_targets_by_group = self.data.get_real_target_for_all_groups()
-
-            if self.data.predicted_target != []:
+            if self.data.predicted_target is not None:
                 y = self.data.df[self.data.predicted_target]
-                if len(self.data.predicted_target) > 1:
-                    y = y.squeeze()
-                if is_binary(y):
-                    if isinstance(y, pd.Series):
-                        if (np.unique(y) != [0, 1]).all():
-                            encode_target(self.data, 0, y.name)
-                    else:
-                        for ind, col in enumerate(y.columns):
-                            if (np.unique(y[col]) != [0, 1]).all():
-                                encode_target(self.data, ind, str(col))
-                self.predicted_targets_by_group = (
+                if is_binary(y) and (np.unique(y) != [0, 1]).all():
+                    encode_target(self.data, y.name)
+                self.predicted_target_by_group = (
                     self.data.get_predicted_target_for_all_groups()
                 )
         else:
@@ -307,7 +292,7 @@ class FairnessMetricDifference(ABC):
         self.metric = metric
         self.label = label
         self.kwargs = kwargs
-        self.targets: Sequence
+        self.target: str
         self.metric_results: list
         self.metric_type = metric_type
         self.data = data
@@ -338,7 +323,7 @@ class FairnessMetricDifference(ABC):
             - values: a numpy array with the corresponding disparity.
         """
         metric = self.metric(self.data, **self.kwargs)
-        self.targets, self.metric_results = metric()
+        self.target, self.metric_results = metric()
         results = calculate_disparity(self.metric_results, "difference")
         return results
 
@@ -361,26 +346,24 @@ class FairnessMetricDifference(ABC):
         """
         if self.results is None:
             self.results = self._compute()
-        self.differences = self.targets, self.results
+        self.differences = self.target, self.results
         self.result = {}
-
-        for target in self.targets:
-            self.result[target] = {
-                self.label: 0.0,
-                "privileged": None,
-                "unprivileged": None,
-            }
+        target = self.target
+        self.result[target] = {
+            self.label: 0.0,
+            "privileged": None,
+            "unprivileged": None,
+        }
 
         for key, value in self.results.items():
-            for ind, target in enumerate(self.targets):
-                if np.abs(value[ind]) > self.result[target][self.label]:
-                    self.result[target][self.label] = np.abs(value[ind])
-                    if value[ind] > 0:
-                        self.result[target][self.label1] = key[0]
-                        self.result[target][self.label2] = key[1]
-                    else:
-                        self.result[target][self.label1] = key[1]
-                        self.result[target][self.label2] = key[0]
+            if np.abs(value[0]) > self.result[target][self.label]:
+                self.result[target][self.label] = np.abs(value[0])
+                if value[0] > 0:
+                    self.result[target][self.label1] = key[0]
+                    self.result[target][self.label2] = key[1]
+                else:
+                    self.result[target][self.label1] = key[1]
+                    self.result[target][self.label2] = key[0]
 
         return self.result
 
@@ -405,34 +388,33 @@ class FairnessMetricDifference(ABC):
         """
         result: dict = {}
         self.ranking = {}
+        target = self.data.real_target
 
-        for target in self.data.real_target:
-            result.setdefault(target, {})
-            self.ranking.setdefault(target, {})
+        result.setdefault(target, {})
+        self.ranking.setdefault(target, {})
 
         if self.results is None:
             self.results = self._compute()
 
         for key, values in self.results.items():
-            for target, value in zip(self.data.real_target, values):
+            for value in values:
                 if self.metric_type == "performance":
                     result[target].setdefault(key[0], []).append(value)
                     result[target].setdefault(key[1], []).append(-value)
                 elif self.metric_type == "error":
                     result[target].setdefault(key[0], []).append(-value)
                     result[target].setdefault(key[1], []).append(value)
-
-        for target, target_result in result.items():
-            for group, differences in target_result.items():
-                difference = np.mean(np.array(differences))
-                self.ranking[target].setdefault(group, difference)
-            self.ranking[target] = dict(
-                sorted(
-                    self.ranking[target].items(),
-                    key=lambda item: item[1],
-                    reverse=True,
-                )
+        target_result = result[target]
+        for group, differences in target_result.items():
+            difference = np.mean(np.array(differences))
+            self.ranking[target].setdefault(group, difference)
+        self.ranking[target] = dict(
+            sorted(
+                self.ranking[target].items(),
+                key=lambda item: item[1],
+                reverse=True,
             )
+        )
 
         return self.ranking
 
@@ -465,13 +447,14 @@ class FairnessMetricDifference(ABC):
             self.ranking = self.rank()
 
         bias: dict = {}
+        target = self.data.real_target
+        dicts = self.ranking[target]
 
-        for target, dicts in self.ranking.items():
-            max_diff, min_diff = list(dicts.values())[0], list(dicts.values())[-1]
-            if max_diff > threshold or min_diff < -threshold:
-                bias[target] = True
-            else:
-                bias[target] = False
+        max_diff, min_diff = list(dicts.values())[0], list(dicts.values())[-1]
+        if max_diff > threshold or min_diff < -threshold:
+            bias[target] = True
+        else:
+            bias[target] = False
 
         return bias
 
@@ -528,7 +511,7 @@ class FairnessMetricRatio(ABC):
         self.kwargs = kwargs
         self.label = label
         self.metric_type = metric_type
-        self.targets: Sequence
+        self.target: Sequence
         self.metric_results: list
         self.result: dict | None = None
         self.ranking: dict | None = None
@@ -546,7 +529,7 @@ class FairnessMetricRatio(ABC):
             - values: a numpy array with the corresponding disparity.
         """
         metric = self.metric(self.data, **self.kwargs)
-        self.targets, self.metric_results = metric()
+        self.target, self.metric_results = metric()
         results = calculate_disparity(self.metric_results, "ratio")
         return results
 
@@ -570,29 +553,28 @@ class FairnessMetricRatio(ABC):
         if self.results is None:
             self.results = self._compute()
 
-        self.ratios = self.targets, self.results
+        self.ratios = self.target, self.results
         self.result = {}
+        target = self.target
 
-        for target in self.targets:
-            self.result[target] = {
-                self.label: 1.0,
-                "privileged": None,
-                "unprivileged": None,
-            }
+        self.result[target] = {
+            self.label: 1.0,
+            "privileged": None,
+            "unprivileged": None,
+        }
 
         for key, value in self.results.items():
-            for ind, target in enumerate(self.targets):
-                if value[ind] > 1:
-                    temp = 1 / value[ind]
-                    key = list(key)
-                    key[0], key[1] = key[1], key[0]
-                else:
-                    temp = value[ind]
+            if value[0] > 1:
+                temp = 1 / value[0]
+                key = list(key)
+                key[0], key[1] = key[1], key[0]
+            else:
+                temp = value[0]
 
-                if temp < self.result[target][self.label]:
-                    self.result[target][self.label] = temp
-                    self.result[target][self.label1] = key[1]
-                    self.result[target][self.label2] = key[0]
+            if temp < self.result[target][self.label]:
+                self.result[target][self.label] = temp
+                self.result[target][self.label1] = key[1]
+                self.result[target][self.label2] = key[0]
 
         return self.result
 
@@ -617,35 +599,34 @@ class FairnessMetricRatio(ABC):
         """
         result: dict = {}
         self.ranking = {}
+        target = self.data.real_target
 
-        for target in self.data.real_target:
-            result.setdefault(target, {})
-            self.ranking.setdefault(target, {})
+        result.setdefault(target, {})
+        self.ranking.setdefault(target, {})
 
         if self.results is None:
             self.results = self._compute()
 
         for key, values in self.results.items():
-            for target, value in zip(self.data.real_target, values):
+            for value in values:
                 if self.metric_type == "performance":
                     result[target].setdefault(key[0], []).append(1 / value)
                     result[target].setdefault(key[1], []).append(value)
                 elif self.metric_type == "error":
                     result[target].setdefault(key[0], []).append(value)
                     result[target].setdefault(key[1], []).append(1 / value)
+        target_result = result[target]
+        for group, ratios in target_result.items():
+            ratio = np.mean(np.array(ratios))
+            self.ranking[target].setdefault(group, ratio)
 
-        for target, target_result in result.items():
-            for group, ratios in target_result.items():
-                ratio = np.mean(np.array(ratios))
-                self.ranking[target].setdefault(group, ratio)
-
-            self.ranking[target] = dict(
-                sorted(
-                    self.ranking[target].items(),
-                    key=lambda item: item[1],
-                    reverse=False,
-                )
+        self.ranking[target] = dict(
+            sorted(
+                self.ranking[target].items(),
+                key=lambda item: item[1],
+                reverse=False,
             )
+        )
 
         return self.ranking
 
@@ -678,12 +659,13 @@ class FairnessMetricRatio(ABC):
             self.ranking = self.rank()
 
         bias: dict = {}
+        target = self.data.real_target
+        dicts = self.ranking[target]
 
-        for target, dicts in self.ranking.items():
-            min_ratio, max_ratio = list(dicts.values())[0], list(dicts.values())[-1]
-            if max_ratio > (1 / threshold) or min_ratio < threshold:
-                bias[target] = True
-            else:
-                bias[target] = False
+        min_ratio, max_ratio = list(dicts.values())[0], list(dicts.values())[-1]
+        if max_ratio > (1 / threshold) or min_ratio < threshold:
+            bias[target] = True
+        else:
+            bias[target] = False
 
         return bias

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -1,7 +1,6 @@
 from collections.abc import Collection, Sequence
 
 import numpy as np
-import pandas as pd
 from numpy.typing import NDArray
 from sklearn.metrics import (  # type: ignore
     accuracy_score,
@@ -195,7 +194,7 @@ class SelectionRate(Metric):
 
     def all_data(
         self,
-    ) -> pd.Series:  # j'ai pas bien compris l'interet mais je vais trouver
+    ) -> dict[str, float]:
         """Compute overall selection rate corresponding to the whole dataset.
 
         Returns
@@ -242,9 +241,13 @@ class SelectionRate(Metric):
         dtype: float64
         """
         if self.use_y_true:
-            return self.data.df[self.data.real_target].mean()
+            return {self.data.real_target: self.data.df[self.data.real_target].mean()}
         else:
-            return self.data.df[self.data.predicted_target].mean()
+            return {
+                self.data.predicted_target: self.data.df[
+                    self.data.predicted_target
+                ].mean()
+            }
 
 
 class ConfusionMatrix(Metric):

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -192,9 +192,7 @@ class SelectionRate(Metric):
             results.append({"sensitive": group_, self.label: np.array(y_group.mean())})
         return target, results
 
-    def all_data(
-        self,
-    ) -> dict[str, float]:
+    def all_data(self) -> dict[str, float]:
         """Compute overall selection rate corresponding to the whole dataset.
 
         Returns

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -42,13 +42,13 @@ class SelectionRate(Metric):
         Sequence of column names corresponding to sensitive features
         (Ex: gender, race...), by default None.
     real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
+        Sequence of column names corresponding to the real target
         (true labels), by default None.
     predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
+        Sequence of column names corresponding to the predicted target,
         by default None.
     positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
+        Sequence of the positive labels corresponding to the provided target,
         by default None.
     """
 
@@ -70,7 +70,7 @@ class SelectionRate(Metric):
         -------
         tuple[Sequence[str], list[dict[str, np.ndarray]]]
             A tuple containing two elements:
-            - targets (Sequence[str]): The target variables used for
+            - target (Sequence[str]): The target variables used for
               calculation.
             - results (list[dict[str, np.ndarray]]): A list of dictionaries,
               where each dictionary has two keys:
@@ -176,24 +176,26 @@ class SelectionRate(Metric):
         """
         results: list = []
         if self.use_y_true:
-            targets = self.data.real_target
-            targets_by_group = self.real_targets_by_group
+            target = self.data.real_target
+            target_by_group = self.real_target_by_group
         else:
-            if self.predicted_targets_by_group == []:
+            if self.predicted_target_by_group == []:
                 raise ValueError(
                     "No predictions found, provide predicted_target parameter "
                     "when creating the dataset or set use_y_true to True to "
                     "use the real labels"
                 )
-            targets = self.data.predicted_target
-            targets_by_group = self.predicted_targets_by_group
-        for group in targets_by_group:
+            target = self.data.predicted_target
+            target_by_group = self.predicted_target_by_group
+        for group in target_by_group:
             group_ = group["sensitive"]
             y_group = group["data"]
             results.append({"sensitive": group_, self.label: np.array(y_group.mean())})
-        return targets, results
+        return target, results
 
-    def all_data(self) -> pd.Series:
+    def all_data(
+        self,
+    ) -> pd.Series:  # j'ai pas bien compris l'interet mais je vais trouver
         """Compute overall selection rate corresponding to the whole dataset.
 
         Returns
@@ -270,13 +272,13 @@ class ConfusionMatrix(Metric):
         Sequence of column names corresponding to sensitive features
         (Ex: gender, race...), by default None.
     real_target : Sequence[str] | None, optional if data is a Dataset object
-        Sequence of column names corresponding to the real targets
+        Sequence of column names corresponding to the real target
         (true labels), by default None.
     predicted_target : Sequence[str] | None, optional
-        Sequence of column names corresponding to the predicted targets,
+        Sequence of column names corresponding to the predicted target,
         by default None.
     positive_target : Sequence[int  |  float  |  str  |  bool] | None, optional
-        Sequence of the positive labels corresponding to the provided targets,
+        Sequence of the positive labels corresponding to the provided target,
         by default None.
 
     Raises
@@ -294,7 +296,7 @@ class ConfusionMatrix(Metric):
         metrics: Collection | Sequence | None = None,
     ) -> None:
         super().__init__(data)
-        if self.predicted_targets_by_group == []:
+        if self.predicted_target_by_group == []:
             raise ValueError(
                 "No predictions found, provide predicted_target parameter "
                 "when creating the dataset"
@@ -336,7 +338,7 @@ class ConfusionMatrix(Metric):
         -------
         tuple[Sequence, list]
             A tuple containing two elements:
-            - targets (Sequence[str]): The target variables used for
+            - target (Sequence[str]): The target variables used for
               calculation.
             - results (list[dict]): A list of dictionaries, where the keys:
                 1. sensitive: The name of the sensitive group.
@@ -438,35 +440,25 @@ class ConfusionMatrix(Metric):
         """
         results: list = []
         for real_group, predicted_group in zip(
-            self.real_targets_by_group, self.predicted_targets_by_group
+            self.real_target_by_group, self.predicted_target_by_group
         ):
             group_ = real_group["sensitive"]
-            real_y_group = real_group["data"]
-            predicted_y_group = predicted_group["data"]
+            real_values = real_group["data"]
+            predicted_values = predicted_group["data"]
             result_for_group = {"sensitive": group_}
-            for real_col, predicted_col in zip(
-                self.data.real_target, self.data.predicted_target
-            ):
-                if len(self.data.real_target) != 1:
-                    real_values = real_y_group[real_col]
-                    predicted_values = predicted_y_group[predicted_col]
-                else:
-                    real_values = real_y_group.iloc[:, 0]
-                    predicted_values = predicted_y_group.iloc[:, 0]
-                conf_matrix = confusion_matrix(
-                    real_values, predicted_values, labels=[0, 1]
-                )
-                tn = conf_matrix[0, 0]
-                tp = conf_matrix[1, 1]
-                fn = conf_matrix[1, 0]
-                fp = conf_matrix[0, 1]
 
-                for metric_name, metric in self.metrics.items():
-                    if metric_name not in result_for_group:
-                        result_for_group[metric_name] = []  # type: ignore
-                    result_for_group[metric_name].append(  # type: ignore
-                        metric(tn=tn, fp=fp, fn=fn, tp=tp)  # type: ignore
-                    )
+            conf_matrix = confusion_matrix(real_values, predicted_values, labels=[0, 1])
+            tn = conf_matrix[0, 0]
+            tp = conf_matrix[1, 1]
+            fn = conf_matrix[1, 0]
+            fp = conf_matrix[0, 1]
+
+            for metric_name, metric in self.metrics.items():
+                if metric_name not in result_for_group:
+                    result_for_group[metric_name] = []  # type: ignore
+                result_for_group[metric_name].append(  # type: ignore
+                    metric(tn=tn, fp=fp, fn=fn, tp=tp)  # type: ignore
+                )
 
             results.append(result_for_group)
 
@@ -514,7 +506,7 @@ class PerformanceMetric(Metric):
     ) -> None:
         super().__init__(data)
 
-        if self.predicted_targets_by_group == []:
+        if self.predicted_target_by_group == []:
             raise ValueError(
                 "No predictions found, provide predicted_target parameter "
                 "when creating the dataset"
@@ -561,7 +553,7 @@ class PerformanceMetric(Metric):
         -------
         tuple[Sequence, list]
             A tuple containing two elements:
-            - targets (Sequence[str]): The target variables used for
+            - target (Sequence[str]): The target variables used for
               calculation.
             - results (list[dict]): A list of dictionaries, where the keys:
                 1. sensitive: The name of the sensitive group.
@@ -666,29 +658,19 @@ class PerformanceMetric(Metric):
         """
         results: list = []
         for real_group, predicted_group in zip(
-            self.real_targets_by_group, self.predicted_targets_by_group
+            self.real_target_by_group, self.predicted_target_by_group
         ):
             group_ = real_group["sensitive"]
-            real_y_group = real_group["data"]
-            predicted_y_group = predicted_group["data"]
-            result_for_group: dict[str, list | pd.DataFrame] = {"sensitive": group_}
+            real_values = real_group["data"]
+            predicted_values = predicted_group["data"]
+            result_for_group = {"sensitive": group_}
 
-            for real_col, predicted_col in zip(
-                self.data.real_target, self.data.predicted_target
-            ):
-                if len(self.data.real_target) != 1:
-                    real_values: pd.Series = real_y_group[real_col]
-                    predicted_values: pd.Series = predicted_y_group[predicted_col]
-                else:
-                    real_values = real_y_group.iloc[:, 0]
-                    predicted_values = predicted_y_group.iloc[:, 0]
-
-                for metric_name, metric in self.metrics.items():
-                    if metric_name not in result_for_group:
-                        result_for_group[metric_name] = []
-                    result_for_group[metric_name].append(
-                        metric(real_values, predicted_values)
-                    )
+            for metric_name, metric in self.metrics.items():
+                if metric_name not in result_for_group:
+                    result_for_group[metric_name] = []  # type: ignore
+                result_for_group[metric_name].append(  # type: ignore
+                    metric(real_values, predicted_values)
+                )
 
             results.append(result_for_group)
 
@@ -701,7 +683,7 @@ class DemographicParityDifference(FairnessMetricDifference):
     in the sensitive feature.
 
     Demographic Parity calculates the "difference" in the Selection Rate in the
-    real targets to detect if there is any bias in the **dataset**.
+    real target to detect if there is any bias in the **dataset**.
 
     The Selection Rate is the ratio of the number of instances selected
     (predicted as positive) to the total number of instances. It is a measure
@@ -774,7 +756,7 @@ class DisparateImpactDifference(FairnessMetricDifference):
     in the sensitive feature.
 
     Disparate Impact calculates the "difference" in the Selection Rate in the
-    predicted targets to detect if there is any bias in the **model**.
+    predicted target to detect if there is any bias in the **model**.
 
     The Selection Rate is the ratio of the number of instances selected
     (predicted as positive) to the total number of instances. It is a measure
@@ -847,7 +829,7 @@ class EqualOpportunityDifference(FairnessMetricDifference):
     in the sensitive feature.
 
     Equal Opportunity calculates the "difference" in the True Positive Rate in
-    the targets to detect if there is any bias in the **model**.
+    the target to detect if there is any bias in the **model**.
 
     The True Positive Rate (TPR) is the ratio of correctly predicted positive
     observations to all actual positives. It is a measure of a model's ability
@@ -920,7 +902,7 @@ class FalsePositiveRateDifference(FairnessMetricDifference):
     in the sensitive feature.
 
     False Positive Rate Parity calculates the "difference" in the False
-    Positive Rate in the targets to detect if there is any bias in the
+    Positive Rate in the target to detect if there is any bias in the
     **model**.
 
     The False Positive Rate (FPR) is the ratio of incorrectly predicted
@@ -995,7 +977,7 @@ class DemographicParityRatio(FairnessMetricRatio):
     sensitive feature.
 
     Demographic Parity calculates the "ratio" of the Selection Rate in the
-    real targets to detect if there is any bias in the **dataset**.
+    real target to detect if there is any bias in the **dataset**.
 
     The Selection Rate is the ratio of the number of instances selected
     (predicted as positive) to the total number of instances. It is a measure
@@ -1065,7 +1047,7 @@ class DisparateImpactRatio(FairnessMetricRatio):
     sensitive feature.
 
     Disparate Impact calculates the "ratio" of the Selection Rate in the
-    predicted targets to detect if there is any bias in the **model**.
+    predicted target to detect if there is any bias in the **model**.
 
     The Selection Rate is the ratio of the number of instances selected
     (predicted as positive) to the total number of instances. It is a measure
@@ -1135,7 +1117,7 @@ class EqualOpportunityRatio(FairnessMetricRatio):
     sensitive feature.
 
     Equal Opportunity calculates the "ratio" of the True Positive Rate in
-    the targets to detect if there is any bias in the **model**.
+    the target to detect if there is any bias in the **model**.
 
     The True Positive Rate (TPR) is the ratio of correctly predicted positive
     observations to all actual positives. It is a measure of a model's ability
@@ -1208,7 +1190,7 @@ class FalsePositiveRateRatio(FairnessMetricRatio):
     in the sensitive feature.
 
     False Positive Rate Parity calculates the "ratio" of the False Positive
-    Rate in the targets to detect if there is any bias in the **model**.
+    Rate in the target to detect if there is any bias in the **model**.
 
     The False Positive Rate (FPR) is the ratio of incorrectly predicted
     positive observations to all actual negatives. It is a measure of the
@@ -1282,7 +1264,7 @@ class EqualisedOddsDifference:
     sensitive feature.
 
     Equalised Odds calculates the "difference" in the True Positive Rate and
-    False Positive Rate in the targets to detect if there is any bias in the
+    False Positive Rate in the target to detect if there is any bias in the
     **model**.
 
     The True Positive Rate (TPR) is the ratio of correctly predicted positive
@@ -1389,17 +1371,17 @@ class EqualisedOddsDifference:
                    group and the discriminated group.
         """
         self.result: dict = {}
+        target = self.data.real_target
 
-        for target in self.data.real_target:
-            self.result.setdefault(
-                target, {self.label: 0.0, "privileged": None, "unprivileged": None}
-            )
+        self.result.setdefault(
+            target, {self.label: 0.0, "privileged": None, "unprivileged": None}
+        )
 
         if (self.tpr is None) or (self.fpr is None):
             self.tpr, self.fpr = self._compute()
 
         for (key1, values1), (_, values2) in zip(self.tpr.items(), self.fpr.items()):
-            for target, value1, value2 in zip(self.data.real_target, values1, values2):
+            for value1, value2 in zip(values1, values2):
                 if np.abs(value1) > self.result[target][self.label]:
                     self.result[target][self.label] = np.abs(value1)
                     if value1 > 0:
@@ -1440,16 +1422,16 @@ class EqualisedOddsDifference:
         """
         result: dict = {}
         self.ranking = {}
+        target = self.data.real_target
 
-        for target in self.data.real_target:
-            result.setdefault(target, {})
-            self.ranking.setdefault(target, {})
+        result.setdefault(target, {})
+        self.ranking.setdefault(target, {})
 
         if (self.tpr is None) or (self.fpr is None):
             self.tpr, self.fpr = self._compute()
 
         for (key1, values1), (_, values2) in zip(self.tpr.items(), self.fpr.items()):
-            for target, value1, value2 in zip(self.data.real_target, values1, values2):
+            for value1, value2 in zip(values1, values2):
                 if np.abs(value1) > np.abs(value2):
                     result[target].setdefault(key1[0], []).append(value1)
                     result[target].setdefault(key1[1], []).append(-value1)
@@ -1457,18 +1439,17 @@ class EqualisedOddsDifference:
                     result[target].setdefault(key1[0], []).append(-value2)
                     result[target].setdefault(key1[1], []).append(value2)
 
-        for target, target_result in result.items():
-            for group, differences in target_result.items():
-                difference = np.mean(np.array(differences))
-                self.ranking[target].setdefault(group, difference)
-
-            self.ranking[target] = dict(
-                sorted(
-                    self.ranking[target].items(),
-                    key=lambda item: item[1],
-                    reverse=True,
-                )
+        target_result = result[target]
+        for group, differences in target_result.items():
+            difference = np.mean(np.array(differences))
+            self.ranking[target].setdefault(group, difference)
+        self.ranking[target] = dict(
+            sorted(
+                self.ranking[target].items(),
+                key=lambda item: item[1],
+                reverse=True,
             )
+        )
 
         return self.ranking
 
@@ -1501,13 +1482,14 @@ class EqualisedOddsDifference:
             self.ranking = self.rank()
 
         bias: dict = {}
+        target = self.data.real_target
+        dicts = self.ranking[target]
 
-        for target, dicts in self.ranking.items():
-            max_diff, min_diff = list(dicts.values())[0], list(dicts.values())[-1]
-            if max_diff > threshold or min_diff < -threshold:
-                bias[target] = True
-            else:
-                bias[target] = False
+        max_diff, min_diff = list(dicts.values())[0], list(dicts.values())[-1]
+        if max_diff > threshold or min_diff < -threshold:
+            bias[target] = True
+        else:
+            bias[target] = False
 
         return bias
 
@@ -1518,7 +1500,7 @@ class EqualisedOddsRatio:
     sensitive feature.
 
     Equalised Odds calculates the "ratio" of the True Positive Rate and False
-    Positive Rate in the targets to detect if there is any bias in the
+    Positive Rate in the target to detect if there is any bias in the
     **model**.
 
     The True Positive Rate (TPR) is the ratio of correctly predicted positive
@@ -1622,17 +1604,17 @@ class EqualisedOddsRatio:
                    group and the discriminated group.
         """
         self.result: dict = {}
+        target = self.data.real_target
 
-        for target in self.data.real_target:
-            self.result.setdefault(
-                target, {self.label: 1.0, "privileged": None, "unprivileged": None}
-            )
+        self.result.setdefault(
+            target, {self.label: 1.0, "privileged": None, "unprivileged": None}
+        )
 
         if (self.tpr is None) or (self.fpr is None):
             self.tpr, self.fpr = self._compute()
 
         for (key1, values1), (_, values2) in zip(self.tpr.items(), self.fpr.items()):
-            for target, value1, value2 in zip(self.data.real_target, values1, values2):
+            for value1, value2 in zip(values1, values2):
                 if value1 > 1:
                     temp = 1 / value1
                 else:
@@ -1685,15 +1667,16 @@ class EqualisedOddsRatio:
         result: dict = {}
         self.ranking = {}
 
-        for target in self.data.real_target:
-            result.setdefault(target, {})
-            self.ranking.setdefault(target, {})
+        target = self.data.real_target
+
+        result.setdefault(target, {})
+        self.ranking.setdefault(target, {})
 
         if (self.tpr is None) or (self.fpr is None):
             self.tpr, self.fpr = self._compute()
 
         for (key1, values1), (_, values2) in zip(self.tpr.items(), self.fpr.items()):
-            for target, value1, value2 in zip(self.data.real_target, values1, values2):
+            for value1, value2 in zip(values1, values2):
                 if value1 > 1:
                     temp1 = 1 / value1
                 else:
@@ -1711,18 +1694,18 @@ class EqualisedOddsRatio:
                     result[target].setdefault(key1[0], []).append(value2)
                     result[target].setdefault(key1[1], []).append(1 / value2)
 
-        for target, target_result in result.items():
-            for group, ratios in target_result.items():
-                ratio = np.mean(np.array(ratios))
-                self.ranking[target].setdefault(group, ratio)
+        target_result = result[target]
+        for group, ratios in target_result.items():
+            ratio = np.mean(np.array(ratios))
+            self.ranking[target].setdefault(group, ratio)
 
-            self.ranking[target] = dict(
-                sorted(
-                    self.ranking[target].items(),
-                    key=lambda item: item[1],
-                    reverse=False,
-                )
+        self.ranking[target] = dict(
+            sorted(
+                self.ranking[target].items(),
+                key=lambda item: item[1],
+                reverse=False,
             )
+        )
 
         return self.ranking
 
@@ -1756,11 +1739,12 @@ class EqualisedOddsRatio:
 
         bias: dict = {}
 
-        for target, dicts in self.ranking.items():
-            min_ratio, max_ratio = list(dicts.values())[0], list(dicts.values())[-1]
-            if max_ratio > (1 / threshold) or min_ratio < threshold:
-                bias[target] = True
-            else:
-                bias[target] = False
+        target = self.data.real_target
+        dicts = self.ranking[target]
+        min_ratio, max_ratio = list(dicts.values())[0], list(dicts.values())[-1]
+        if max_ratio > (1 / threshold) or min_ratio < threshold:
+            bias[target] = True
+        else:
+            bias[target] = False
 
         return bias

--- a/fair_mango/metrics/metrics.py
+++ b/fair_mango/metrics/metrics.py
@@ -175,10 +175,10 @@ class SelectionRate(Metric):
         """
         results: list = []
         if self.use_y_true:
-            target = self.data.real_target
+            target: str = self.data.real_target
             target_by_group = self.real_target_by_group
         else:
-            if self.predicted_target_by_group == []:
+            if self.data.predicted_target is None:
                 raise ValueError(
                     "No predictions found, provide predicted_target parameter "
                     "when creating the dataset or set use_y_true to True to "
@@ -241,11 +241,18 @@ class SelectionRate(Metric):
         if self.use_y_true:
             return {self.data.real_target: self.data.df[self.data.real_target].mean()}
         else:
-            return {
-                self.data.predicted_target: self.data.df[
-                    self.data.predicted_target
-                ].mean()
-            }
+            if self.data.predicted_target is None:
+                raise ValueError(
+                    "No predictions found, provide predicted_target parameter "
+                    "when creating the dataset or set use_y_true to True to "
+                    "use the real labels"
+                )
+            else:
+                return {
+                    self.data.predicted_target: self.data.df[
+                        self.data.predicted_target
+                    ].mean()
+                }
 
 
 class ConfusionMatrix(Metric):

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -8,7 +8,6 @@ import pytest
 from fair_mango.dataset.dataset import (
     Dataset,
     check_column_existence_in_df,
-    check_real_and_predicted_target_match,
     validate_columns,
 )
 
@@ -16,20 +15,20 @@ df = pd.read_csv("tests/data/heart_data.csv")
 
 df2 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]})
 
-dataset1 = Dataset(df, ["Sex"], ["HeartDisease"])
+dataset1 = Dataset(df, "Sex", "HeartDisease")
 
-dataset2 = Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset2 = Dataset(df, "Sex", "HeartDisease", "HeartDiseasePred")
 
-dataset3 = Dataset(df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset3 = Dataset(df, ["Sex", "ChestPainType"], "HeartDisease", "HeartDiseasePred")
 
-dataset4 = Dataset(df, ["Sex"], ["HeartDisease", "ExerciseAngina"], None, [1, "Y"])
+dataset4 = Dataset(df, "Sex", "HeartDisease", None, 1)
 
 dataset5 = Dataset(
     df,
-    ["Sex"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "Sex",
+    "ExerciseAngina",
+    "ExerciseAnginaPred",
+    "Y",
 )
 
 
@@ -54,90 +53,67 @@ def test_check_column_existence_in_df(
 
 
 @pytest.mark.parametrize(
-    "real_target, predicted_target, expected_result",
-    [
-        (["A"], ["a"], None),
-        (["a", "b"], ["A", "B"], None),
-        ([], [], None),
-        (["D"], [], pytest.raises(ValueError)),
-        ([], ["D"], pytest.raises(ValueError)),
-        (["C", "c"], ["D"], pytest.raises(ValueError)),
-    ],
-)
-def test_check_real_and_predicted_target_match(
-    real_target: Sequence[str],
-    predicted_target: Sequence[str],
-    expected_result: None | AbstractContextManager,
-):
-    if expected_result is not None:
-        with expected_result:
-            check_real_and_predicted_target_match(real_target, predicted_target)
-    else:
-        check_real_and_predicted_target_match(real_target, predicted_target)
-
-
-@pytest.mark.parametrize(
     "df, sensitive, real_target, predicted_target, positive_target, group_count, expected_result",
     [
-        (df, ["Sex"], ["HeartDisease"], None, None, (725, 193), None),
-        (df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"], None, (725, 193), None),
+        (df, "Sex", "HeartDisease", None, None, (725, 193), None),
+        (df, "Sex", "HeartDisease", "HeartDiseasePred", None, (725, 193), None),
         (
             df,
             ["Sex", "ChestPainType"],
-            ["HeartDisease"],
-            ["HeartDiseasePred"],
+            "HeartDisease",
+            "HeartDiseasePred",
             None,
             [426, 150, 113, 70, 60, 53, 36, 10],
             None,
         ),
         (df, "Sex", "HeartDisease", "HeartDiseasePred", None, (725, 193), None),
-        (df, ["Sex"], ["ExerciseAngina"], None, None, (725, 193), None),
-        (df, ["Sex"], ["ExerciseAngina"], None, ["Y"], (725, 193), None),
+        (df, "Sex", "ExerciseAngina", None, None, (725, 193), None),
+        (df, "Sex", "ExerciseAngina", None, "Y", (725, 193), None),
         (
             df,
-            ["Sex"],
-            ["HeartDisease", "ExerciseAngina"],
+            "Sex",
+            "HeartDisease",
             ["HeartDiseasePred", "ExerciseAnginaPred"],
             [1, "Y"],
             (725, 193),
-            None,
+            pytest.raises(TypeError),
         ),
         (
             df,
             ["NewColumn"],
-            ["HeartDisease"],
+            "HeartDisease",
             None,
             None,
             (725, 193),
             pytest.raises(KeyError),
         ),
-        (df, ["Sex"], ["NewColumn"], None, None, (725, 193), pytest.raises(KeyError)),
+        (df, "Sex", "NewColumn", None, None, (725, 193), pytest.raises(KeyError)),
         (
             df,
-            ["Sex"],
-            ["HeartDisease"],
-            ["NewColumn"],
+            "Sex",
+            "HeartDisease",
+            "NewColumn",
             None,
             (725, 193),
             pytest.raises(KeyError),
         ),
         (
             df,
-            ["Sex"],
-            ["HeartDisease"],
+            "Sex",
+            "HeartDisease",
             ["HeartDisease", "HeartDiseasePred"],
             None,
             (725, 193),
-            pytest.raises(ValueError),
+            pytest.raises(TypeError),
         ),
     ],
 )
 def test_dataset_init(
     df: pd.DataFrame,
     sensitive: Sequence[str],
-    real_target: Sequence[str],
-    predicted_target: Sequence[str],
-    positive_target: Sequence[int | float | str | bool] | None,
+    real_target: str,
+    predicted_target: str,
+    positive_target: int | float | str | bool | None,
     group_count: Sequence[int],
     expected_result: None | AbstractContextManager,
 ):
@@ -221,8 +197,8 @@ def test_get_data_for_one_group(
 @pytest.mark.parametrize(
     "dataset, sensitive_groups, expected_data_type, expected_data_shape",
     [
-        (dataset1, [["M"], ["F"]], pd.DataFrame, [(725, 1), (193, 1)]),
-        (dataset2, [["M"], ["F"]], pd.DataFrame, [(725, 1), (193, 1)]),
+        (dataset1, [["M"], ["F"]], pd.Series, [(725,), (193,)]),
+        (dataset2, [["M"], ["F"]], pd.Series, [(725,), (193,)]),
         (
             dataset3,
             [
@@ -235,11 +211,11 @@ def test_get_data_for_one_group(
                 ["M", "TA"],
                 ["F", "TA"],
             ],
-            pd.DataFrame,
-            [(426, 1), (150, 1), (113, 1), (70, 1), (60, 1), (53, 1), (36, 1), (10, 1)],
+            pd.Series,
+            [(426,), (150,), (113,), (70,), (60,), (53,), (36,), (10,)],
         ),
-        (dataset4, [["M"], ["F"]], pd.DataFrame, [(725, 2), (193, 2)]),
-        (dataset5, [["M"], ["F"]], pd.DataFrame, [(725, 2), (193, 2)]),
+        (dataset4, [["M"], ["F"]], pd.Series, [(725,), (193,)]),
+        (dataset5, [["M"], ["F"]], pd.Series, [(725,), (193,)]),
     ],
 )
 def test_get_real_target_for_all_groups(
@@ -264,11 +240,11 @@ def test_get_real_target_for_all_groups(
         (
             dataset1,
             [["M"], ["F"]],
-            pd.DataFrame,
-            [(725, 1), (193, 1)],
+            pd.Series,
+            [(725,), (193,)],
             pytest.raises(ValueError),
         ),
-        (dataset2, [["M"], ["F"]], pd.DataFrame, [(725, 1), (193, 1)], None),
+        (dataset2, [["M"], ["F"]], pd.Series, [(725,), (193,)], None),
         (
             dataset3,
             [
@@ -281,18 +257,18 @@ def test_get_real_target_for_all_groups(
                 ["M", "TA"],
                 ["F", "TA"],
             ],
-            pd.DataFrame,
-            [(426, 1), (150, 1), (113, 1), (70, 1), (60, 1), (53, 1), (36, 1), (10, 1)],
+            pd.Series,
+            [(426,), (150,), (113,), (70,), (60,), (53,), (36,), (10,)],
             None,
         ),
         (
             dataset4,
             [["M"], ["F"]],
-            pd.DataFrame,
+            pd.Series,
             [(725, 2), (193, 2)],
             pytest.raises(ValueError),
         ),
-        (dataset5, [["M"], ["F"]], pd.DataFrame, [(725, 2), (193, 2)], None),
+        (dataset5, [["M"], ["F"]], pd.Series, [(725,), (193,)], None),
     ],
 )
 def test_get_predicted_target_for_all_groups(
@@ -319,16 +295,16 @@ def test_get_predicted_target_for_all_groups(
 @pytest.mark.parametrize(
     "dataset, sensitive_groups, expected_data_type, expected_data_shape",
     [
-        (dataset1, ["M"], pd.DataFrame, (725, 1)),
-        (dataset4, "F", pd.DataFrame, (193, 2)),
-        (dataset3, ["M", "ASY"], pd.DataFrame, (426, 1)),
-        (dataset3, ["F", "ASY"], pd.DataFrame, (70, 1)),
+        (dataset1, ["M"], pd.Series, (725,)),
+        (dataset4, "F", pd.Series, (193,)),
+        (dataset3, ["M", "ASY"], pd.Series, (426,)),
+        (dataset3, ["F", "ASY"], pd.Series, (70,)),
     ],
 )
 def test_get_real_target_for_one_group(
     dataset: Dataset,
     sensitive_groups: Sequence,
-    expected_data_type: type[pd.DataFrame],
+    expected_data_type: type[pd.Series],
     expected_data_shape: Sequence,
 ):
     result = dataset.get_real_target_for_one_group(sensitive_groups)
@@ -339,17 +315,17 @@ def test_get_real_target_for_one_group(
 @pytest.mark.parametrize(
     "dataset, sensitive_groups, expected_data_type, expected_data_shape, exception",
     [
-        (dataset1, ["M"], pd.DataFrame, (725, 1), pytest.raises(ValueError)),
-        (dataset4, "F", pd.DataFrame, (193, 2), pytest.raises(ValueError)),
-        (dataset3, ["M", "ASY"], pd.DataFrame, (426, 1), None),
-        (dataset3, ["F", "ASY"], pd.DataFrame, (70, 1), None),
-        (dataset5, "F", pd.DataFrame, (193, 2), None),
+        (dataset1, ["M"], pd.Series, (725,), pytest.raises(ValueError)),
+        (dataset4, "F", pd.Series, (193,), pytest.raises(ValueError)),
+        (dataset3, ["M", "ASY"], pd.Series, (426,), None),
+        (dataset3, ["F", "ASY"], pd.Series, (70,), None),
+        (dataset5, "F", pd.Series, (193,), None),
     ],
 )
 def test_get_predicted_target_for_one_group(
     dataset: Dataset,
     sensitive_groups: Sequence,
-    expected_data_type: type[pd.DataFrame],
+    expected_data_type: type[pd.Series],
     expected_data_shape: Sequence,
     exception: None | AbstractContextManager,
 ):
@@ -365,17 +341,17 @@ def test_get_predicted_target_for_one_group(
 @pytest.mark.parametrize(
     "sensitive, real_target, predicted_target, expected_result",
     [
-        (["gender"], ["r1", "r2"], None, None),
-        (["gender", "race"], ["r1", "r2"], ["p1", "p2"], None),
-        (["gender"], ["r1", "r2"], ["r1", "p2"], pytest.raises(AttributeError)),
-        (["race"], ["race", "r2"], None, pytest.raises(AttributeError)),
-        (["gender", "race"], ["r1"], ["gender"], pytest.raises(AttributeError)),
+        # (["gender"], ["r1", "r2"], None, None),
+        # (["gender", "race"], ["r1", "r2"], ["p1", "p2"], None),
+        # (["gender"], ["r1", "r2"], ["r1", "p2"], pytest.raises(AttributeError)),
+        # (["race"], ["race", "r2"], None, pytest.raises(AttributeError)),
+        (["gender", "race"], "r1", "gender", pytest.raises(AttributeError)),
     ],
 )
 def test_validate_columns(
     sensitive: Sequence[str],
-    real_target: Sequence[str],
-    predicted_target: Sequence[str] | None,
+    real_target: str,
+    predicted_target: str | None,
     expected_result: None | AbstractContextManager,
 ):
     if expected_result is not None:

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -341,10 +341,9 @@ def test_get_predicted_target_for_one_group(
 @pytest.mark.parametrize(
     "sensitive, real_target, predicted_target, expected_result",
     [
-        # (["gender"], ["r1", "r2"], None, None),
-        # (["gender", "race"], ["r1", "r2"], ["p1", "p2"], None),
-        # (["gender"], ["r1", "r2"], ["r1", "p2"], pytest.raises(AttributeError)),
-        # (["race"], ["race", "r2"], None, pytest.raises(AttributeError)),
+        (["gender"], "r1", None, None),
+        (["gender", "race"], "r1", "p1", None),
+        (["race"], "race", None, pytest.raises(AttributeError)),
         (["gender", "race"], "r1", "gender", pytest.raises(AttributeError)),
     ],
 )

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -8,28 +8,28 @@ from fair_mango.metrics.base import encode_target, is_binary
 
 df = pd.read_csv("tests/data/heart_data.csv")
 
-dataset1 = Dataset(df, ["Sex"], ["HeartDisease"])
+dataset1 = Dataset(df, ["Sex"], "HeartDisease")
 
-dataset2 = Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset2 = Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred")
 
-dataset3 = Dataset(df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset3 = Dataset(df, ["Sex", "ChestPainType"], "HeartDisease", "HeartDiseasePred")
 
-dataset4 = Dataset(df, ["Sex"], ["HeartDisease", "ExerciseAngina"], None, [1, "Y"])
+dataset4 = Dataset(df, ["Sex"], "HeartDisease", None, 1)
 
 dataset5 = Dataset(
     df,
     ["Sex"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "ExerciseAngina",
+    "ExerciseAnginaPred",
+    "Y",
 )
 
 dataset6 = Dataset(
     df,
     ["Sex", "ChestPainType"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "HeartDisease",
+    "HeartDiseasePred",
+    1,
 )
 
 
@@ -47,20 +47,20 @@ def test_is_binary(y: pd.Series | pd.DataFrame, expected_result: bool):
 
 
 @pytest.mark.parametrize(
-    "data, ind, col, expected_result",
+    "data, col, expected_result",
     [
-        (dataset4, 0, "HeartDisease", None),
-        (dataset5, 1, "ExerciseAngina", None),
-        (dataset5, 1, "HeartDiseasePred", pytest.raises(KeyError)),
-        (dataset3, 0, "ExerciseAngina", pytest.raises(ValueError)),
+        (dataset4, "HeartDisease", None),
+        (dataset5, "ExerciseAngina", None),
+        (dataset5, "HeartDiseasePred", pytest.raises(KeyError)),
+        (dataset3, "ExerciseAngina", pytest.raises(ValueError)),
     ],
 )
 def test_encode_target(
-    data: Dataset, ind: int, col: str, expected_result: None | AbstractContextManager
+    data: Dataset, col: str, expected_result: None | AbstractContextManager
 ):
     if expected_result is None:
-        encode_target(data, ind, col)
+        encode_target(data, col)
         assert sorted(data.df[col].unique()) == [0, 1]
     else:
         with expected_result:
-            encode_target(data, ind, col)
+            encode_target(data, col)

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -39,10 +39,9 @@ dataset6 = Dataset(
         (df["Sex"], True),
         (df["ExerciseAngina"], True),
         (df["ChestPainType"], False),
-        (df[["ExerciseAngina", "Sex"]], True),
     ],
 )
-def test_is_binary(y: pd.Series | pd.DataFrame, expected_result: bool):
+def test_is_binary(y: pd.Series, expected_result: bool):
     assert is_binary(y) == expected_result
 
 

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -32,28 +32,28 @@ from fair_mango.metrics.metrics import (
 
 df = pd.read_csv("tests/data/heart_data.csv")
 
-dataset1 = Dataset(df, ["Sex"], ["HeartDisease"])
+dataset1 = Dataset(df, "Sex", "HeartDisease")
 
-dataset2 = Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset2 = Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred")
 
-dataset3 = Dataset(df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset3 = Dataset(df, ["Sex", "ChestPainType"], "HeartDisease", "HeartDiseasePred")
 
-dataset4 = Dataset(df, ["Sex"], ["HeartDisease", "ExerciseAngina"], None, [1, "Y"])
+dataset4 = Dataset(df, ["Sex"], "HeartDisease", None, 1)
 
 dataset5 = Dataset(
     df,
     ["Sex"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "ExerciseAngina",
+    "ExerciseAnginaPred",
+    "Y",
 )
 
 dataset6 = Dataset(
     df,
     ["Sex", "ChestPainType"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "HeartDisease",
+    "HeartDiseasePred",
+    1,
 )
 
 
@@ -250,7 +250,7 @@ def test_confusionmatrix(
                 else:
                     for val, expected_val in zip(res[key], expected_result[i][key]):
                         if np.isnan(val) and np.isnan(expected_val):
-                            assert True
+                            continue
                         else:
                             assert (np.isclose(val, expected_val)).all()
 
@@ -344,8 +344,8 @@ dpd_expected_result_6 = [
             Dataset(
                 df,
                 ["Sex", "ChestPainType"],
-                ["HeartDisease"],
-                ["HeartDiseasePred"],
+                "HeartDisease",
+                "HeartDiseasePred",
             ),
             "demographic_parity_difference",
             0.1,
@@ -469,7 +469,7 @@ dpr_expected_result_6 = [
     [
         (dataset1, "dpr", 1.2, dpr_expected_result_1),
         (
-            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
+            Dataset(df, "Sex", "HeartDisease", "HeartDiseasePred"),
             "dpr",
             0.4,
             dpr_expected_result_2,
@@ -594,13 +594,7 @@ did_expected_result_6 = [
             did_expected_result_3,
         ),
         (
-            Dataset(
-                df,
-                ["Sex", "ChestPainType"],
-                ["HeartDisease", "ExerciseAngina"],
-                ["HeartDiseasePred", "ExerciseAnginaPred"],
-                [1, "Y"],
-            ),
+            dataset6,
             "disparate_impact_difference",
             0.45,
             did_expected_result_6,
@@ -713,7 +707,7 @@ dir_expected_result_6 = [
             pytest.raises(ValueError),
         ),
         (
-            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
+            Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred"),
             "dir",
             0.4,
             dir_expected_result_2,
@@ -837,8 +831,8 @@ eod_expected_result_6 = [
             Dataset(
                 df,
                 ["Sex", "ChestPainType"],
-                ["HeartDisease"],
-                ["HeartDiseasePred"],
+                "HeartDisease",
+                "HeartDiseasePred",
             ),
             "equal_opportunity_difference",
             0.2,
@@ -959,7 +953,7 @@ eor_expected_result_6 = [
             pytest.raises(ValueError),
         ),
         (
-            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
+            Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred"),
             "eor",
             0.4,
             eor_expected_result_2,
@@ -1130,7 +1124,7 @@ performancemetrics_expected_result_6 = [
             pytest.raises(KeyError),
         ),
         (
-            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
+            Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred"),
             None,
             performancemetrics_expected_result_2,
         ),
@@ -1258,9 +1252,7 @@ eod_expected_result_6 = [
     [
         (dataset2, 0.1, eod_expected_result_2),
         (
-            Dataset(
-                df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"]
-            ),
+            Dataset(df, ["Sex", "ChestPainType"], "HeartDisease", "HeartDiseasePred"),
             0.2,
             eod_expected_result_3,
         ),
@@ -1337,7 +1329,7 @@ eor_expected_result_3 = [
             pytest.raises(ValueError),
         ),
         (
-            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
+            Dataset(df, "Sex", "HeartDisease", "HeartDiseasePred"),
             0.4,
             eor_expected_result_2,
         ),
@@ -1345,7 +1337,7 @@ eor_expected_result_3 = [
             dataset3,
             0.8,
             eor_expected_result_3,
-        ),
+        ),  # rajouter un test ici
     ],
 )
 def test_equalised_odds_ratio(

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -114,13 +114,13 @@ dataset6 = Dataset(
             dataset5,
             True,
             ["M", "F"],
-            [[0.63172414, 0.45241379], [0.25906736, 0.22279793]],
+            [0.45241379, 0.22279793],
         ),
         (
             dataset5,
             False,
             ["M", "F"],
-            [[0.6262069, 0.45241379], [0.2642487, 0.22279793]],
+            [0.45241379, 0.22279793],
         ),
     ],
 )
@@ -179,43 +179,45 @@ confusionmatrix_expected_result_3 = [
 confusionmatrix_expected_result_6 = [
     {
         "sensitive": np.array(["M", "ASY"]),
-        "true_negative_rate": [0.9863013698630136, 1.0],
-        "false_negative_rate": [0.014164305949008499, 0.0],
+        "true_negative_rate": [0.9863013698630136],
+        "false_negative_rate": [0.014164305949008499],
     },
     {
         "sensitive": np.array(["M", "NAP"]),
-        "true_negative_rate": [0.9880952380952381, 1.0],
-        "false_negative_rate": [0.015151515151515152, 0.0],
+        "true_negative_rate": [0.9880952380952381],
+        "false_negative_rate": [0.015151515151515152],
     },
     {
         "sensitive": np.array(["M", "ATA"]),
-        "true_negative_rate": [0.989247311827957, 1.0],
-        "false_negative_rate": [0.05, 0.0],
+        "true_negative_rate": [0.989247311827957],
+        "false_negative_rate": [0.05],
     },
     {
         "sensitive": np.array(["F", "ASY"]),
-        "true_negative_rate": [0.9032258064516129, 1.0],
-        "false_negative_rate": [0.02564102564102564, 0.0],
+        "true_negative_rate": [0.9032258064516129],
+        "false_negative_rate": [0.02564102564102564],
     },
     {
         "sensitive": np.array(["F", "ATA"]),
-        "true_negative_rate": [0.9821428571428571, 1.0],
-        "false_negative_rate": [0.0, 0.0],
+        "true_negative_rate": [0.9821428571428571],
+        "false_negative_rate": [
+            0.0,
+        ],
     },
     {
         "sensitive": np.array(["F", "NAP"]),
-        "true_negative_rate": [1.0, 1.0],
-        "false_negative_rate": [0.3333333333333333, 0.0],
+        "true_negative_rate": [1.0],
+        "false_negative_rate": [0.3333333333333333],
     },
     {
         "sensitive": np.array(["M", "TA"]),
-        "true_negative_rate": [0.8235294117647058, 1.0],
-        "false_negative_rate": [0.15789473684210525, 0.0],
+        "true_negative_rate": [0.8235294117647058],
+        "false_negative_rate": [0.15789473684210525],
     },
     {
         "sensitive": np.array(["F", "TA"]),
-        "true_negative_rate": [1.0, 1.0],
-        "false_negative_rate": [0.0, np.nan],
+        "true_negative_rate": [1.0],
+        "false_negative_rate": [0.0],
     },
 ]
 
@@ -248,7 +250,9 @@ def test_confusionmatrix(
                 if key == "sensitive":
                     assert (res[key] == expected_result[i][key]).all()
                 else:
-                    for val, expected_val in zip(res[key], expected_result[i][key]):
+                    for val, expected_val in zip(
+                        res[key], expected_result[i][key], strict=True
+                    ):
                         if np.isnan(val) and np.isnan(expected_val):
                             continue
                         else:
@@ -304,11 +308,6 @@ dpd_expected_result_6 = [
             "privileged": ("M", "ASY"),
             "unprivileged": ("F", "ATA"),
         },
-        "ExerciseAngina": {
-            "demographic_parity_difference": 0.6197183098591549,
-            "privileged": ("M", "ASY"),
-            "unprivileged": ("F", "TA"),
-        },
     },
     {
         "HeartDisease": {
@@ -321,18 +320,8 @@ dpd_expected_result_6 = [
             ("F", "TA"): -0.28720349955031044,
             ("F", "ATA"): -0.32529873764554856,
         },
-        "ExerciseAngina": {
-            ("M", "ASY"): 0.44419980257312147,
-            ("F", "ASY"): 0.27472581579531175,
-            ("M", "NAP"): 0.08642649606742059,
-            ("M", "TA"): -0.07357350393257941,
-            ("M", "ATA"): -0.14268433410535647,
-            ("F", "NAP"): -0.1562329828184734,
-            ("F", "ATA"): -0.16881159917067465,
-            ("F", "TA"): -0.26404969440876985,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": False},
+    {"HeartDisease": True},
 ]
 
 
@@ -432,11 +421,6 @@ dpr_expected_result_6 = [
             "privileged": ("M", "ASY"),
             "unprivileged": ("F", "ATA"),
         },
-        "ExerciseAngina": {
-            "demographic_parity_ratio": 0.0,
-            "privileged": ("F", "TA"),
-            "unprivileged": ("M", "ASY"),
-        },
     },
     {
         "HeartDisease": {
@@ -449,18 +433,8 @@ dpr_expected_result_6 = [
             ("F", "ASY"): 0.5777645230023888,
             ("M", "ASY"): 0.341659585454887,
         },
-        "ExerciseAngina": {
-            ("F", "TA"): np.inf,
-            ("F", "ATA"): 3.0257391900480957,
-            ("F", "NAP"): 2.6560696178758176,
-            ("M", "ATA"): 2.34361081282544,
-            ("M", "TA"): 1.4414410235954764,
-            ("M", "NAP"): 0.7181744693453675,
-            ("F", "ASY"): 0.4172482695250963,
-            ("M", "ASY"): 0.28322304584791763,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": True},
+    {"HeartDisease": True},
 ]
 
 
@@ -551,11 +525,6 @@ did_expected_result_6 = [
             "privileged": ("M", "ASY"),
             "unprivileged": ("F", "NAP"),
         },
-        "ExerciseAnginaPred": {
-            "disparate_impact_difference": 0.6197183098591549,
-            "privileged": ("M", "ASY"),
-            "unprivileged": ("F", "TA"),
-        },
     },
     {
         "HeartDisease": {
@@ -568,18 +537,8 @@ did_expected_result_6 = [
             ("F", "ASY"): 0.26816817343458915,
             ("M", "ASY"): 0.5350647912366394,
         },
-        "ExerciseAngina": {
-            ("F", "TA"): -0.26404969440876985,
-            ("F", "ATA"): -0.16881159917067465,
-            ("F", "NAP"): -0.1562329828184734,
-            ("M", "ATA"): -0.14268433410535647,
-            ("M", "TA"): -0.07357350393257941,
-            ("M", "NAP"): 0.08642649606742059,
-            ("F", "ASY"): 0.27472581579531175,
-            ("M", "ASY"): 0.44419980257312147,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": False},
+    {"HeartDisease": True},
 ]
 
 
@@ -665,11 +624,6 @@ dir_expected_result_6 = [
             "privileged": ("M", "ASY"),
             "unprivileged": ("F", "NAP"),
         },
-        "ExerciseAnginaPred": {
-            "disparate_impact_ratio": 0.0,
-            "privileged": ("F", "TA"),
-            "unprivileged": ("M", "ASY"),
-        },
     },
     {
         "HeartDisease": {
@@ -682,18 +636,8 @@ dir_expected_result_6 = [
             ("F", "ASY"): 0.5421518990141162,
             ("M", "ASY"): 0.3468836645650188,
         },
-        "ExerciseAngina": {
-            ("F", "TA"): np.inf,
-            ("F", "ATA"): 3.0257391900480957,
-            ("F", "NAP"): 2.6560696178758176,
-            ("M", "ATA"): 2.34361081282544,
-            ("M", "TA"): 1.4414410235954764,
-            ("M", "NAP"): 0.7181744693453675,
-            ("F", "ASY"): 0.4172482695250963,
-            ("M", "ASY"): 0.28322304584791763,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": True},
+    {"HeartDisease": True},
 ]
 
 
@@ -791,11 +735,6 @@ eod_expected_result_6 = [
             "privileged": ("F", "ATA"),
             "unprivileged": ("F", "NAP"),
         },
-        "ExerciseAngina": {
-            "equal_opportunity_difference": 0.0,
-            "privileged": None,
-            "unprivileged": None,
-        },
     },
     {
         "HeartDisease": {
@@ -808,18 +747,8 @@ eod_expected_result_6 = [
             ("M", "TA"): -0.09528185397426492,
             ("F", "NAP"): -0.29578310710709704,
         },
-        "ExerciseAngina": {
-            ("M", "ASY"): np.nan,
-            ("M", "NAP"): np.nan,
-            ("M", "ATA"): np.nan,
-            ("F", "ASY"): np.nan,
-            ("F", "ATA"): np.nan,
-            ("F", "NAP"): np.nan,
-            ("M", "TA"): np.nan,
-            ("F", "TA"): np.nan,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": False},
+    {"HeartDisease": True},
 ]
 
 
@@ -911,11 +840,6 @@ eor_expected_result_6 = [
             "privileged": ("F", "ATA"),
             "unprivileged": ("F", "NAP"),
         },
-        "ExerciseAngina": {
-            "equal_opportunity_ratio": 1.0,
-            "privileged": None,
-            "unprivileged": None,
-        },
     },
     {
         "HeartDisease": {
@@ -928,18 +852,8 @@ eor_expected_result_6 = [
             ("M", "TA"): 1.1131472015944397,
             ("F", "NAP"): 1.4436746606606454,
         },
-        "ExerciseAngina": {
-            ("M", "ASY"): np.nan,
-            ("M", "NAP"): np.nan,
-            ("M", "ATA"): np.nan,
-            ("F", "ASY"): np.nan,
-            ("F", "ATA"): np.nan,
-            ("F", "NAP"): np.nan,
-            ("M", "TA"): np.nan,
-            ("F", "TA"): np.nan,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": False},
+    {"HeartDisease": True},
 ]
 
 
@@ -1065,51 +979,73 @@ performancemetrics_expected_result_3 = [
 performancemetrics_expected_result_6 = [
     {
         "sensitive": np.array(["M", "ASY"], dtype=object),
-        "precision_score": [0.997134670487106, 1.0],
-        "recall_score": [0.9858356940509915, 1.0],
-        "f1_score": [0.9914529914529915, 1.0],
+        "precision_score": [0.997134670487106],
+        "recall_score": [
+            0.9858356940509915,
+        ],
+        "f1_score": [
+            0.9914529914529915,
+        ],
     },
     {
         "sensitive": np.array(["M", "NAP"], dtype=object),
-        "precision_score": [0.9848484848484849, 1.0],
-        "recall_score": [0.9848484848484849, 1.0],
-        "f1_score": [0.9848484848484849, 1.0],
+        "precision_score": [
+            0.9848484848484849,
+        ],
+        "recall_score": [
+            0.9848484848484849,
+        ],
+        "f1_score": [
+            0.9848484848484849,
+        ],
     },
     {
         "sensitive": np.array(["M", "ATA"], dtype=object),
-        "precision_score": [0.95, 1.0],
-        "recall_score": [0.95, 1.0],
-        "f1_score": [0.95, 1.0],
+        "precision_score": [
+            0.95,
+        ],
+        "recall_score": [
+            0.95,
+        ],
+        "f1_score": [
+            0.95,
+        ],
     },
     {
         "sensitive": np.array(["F", "ASY"], dtype=object),
-        "precision_score": [0.926829268292683, 1.0],
-        "recall_score": [0.9743589743589743, 1.0],
-        "f1_score": [0.95, 1.0],
+        "precision_score": [
+            0.926829268292683,
+        ],
+        "recall_score": [
+            0.9743589743589743,
+        ],
+        "f1_score": [
+            0.95,
+        ],
     },
     {
         "sensitive": np.array(["F", "ATA"], dtype=object),
-        "precision_score": [0.8, 1.0],
-        "recall_score": [1.0, 1.0],
-        "f1_score": [0.8888888888888888, 1.0],
+        "precision_score": [0.8],
+        "recall_score": [1.0],
+        "f1_score": [0.8888888888888888],
     },
     {
         "sensitive": np.array(["F", "NAP"], dtype=object),
-        "precision_score": [1.0, 1.0],
-        "recall_score": [0.6666666666666666, 1.0],
-        "f1_score": [0.8, 1.0],
+        "precision_score": [1.0],
+        "recall_score": [0.6666666666666666],
+        "f1_score": [0.8],
     },
     {
         "sensitive": np.array(["M", "TA"], dtype=object),
-        "precision_score": [0.8421052631578947, 1.0],
-        "recall_score": [0.8421052631578947, 1.0],
-        "f1_score": [0.8421052631578947, 1.0],
+        "precision_score": [0.8421052631578947],
+        "recall_score": [0.8421052631578947],
+        "f1_score": [0.8421052631578947],
     },
     {
         "sensitive": np.array(["F", "TA"], dtype=object),
-        "precision_score": [1.0, 0.0],
-        "recall_score": [1.0, 0.0],
-        "f1_score": [1.0, 0.0],
+        "precision_score": [1.0],
+        "recall_score": [1.0],
+        "f1_score": [1.0],
     },
 ]
 
@@ -1215,11 +1151,6 @@ eod_expected_result_6 = [
             "privileged": ("F", "ATA"),
             "unprivileged": ("F", "NAP"),
         },
-        "ExerciseAngina": {
-            "equalised_odds_difference": 0.0,
-            "privileged": None,
-            "unprivileged": None,
-        },
     },
     {
         "HeartDisease": {
@@ -1232,18 +1163,8 @@ eod_expected_result_6 = [
             ("M", "TA"): -0.16240914536313006,
             ("F", "NAP"): -0.24551036643187954,
         },
-        "ExerciseAngina": {
-            ("M", "ASY"): 0.0,
-            ("M", "NAP"): 0.0,
-            ("M", "ATA"): 0.0,
-            ("F", "ASY"): 0.0,
-            ("F", "ATA"): 0.0,
-            ("F", "NAP"): 0.0,
-            ("M", "TA"): 0.0,
-            ("F", "TA"): 0.0,
-        },
     },
-    {"HeartDisease": True, "ExerciseAngina": False},
+    {"HeartDisease": True},
 ]
 
 
@@ -1319,6 +1240,29 @@ eor_expected_result_3 = [
     {"HeartDisease": False},
 ]
 
+eor_expected_result_6 = [
+    {
+        "HeartDisease": {
+            "equalised_odds_ratio": np.float64(0.0),
+            "privileged": ("F", "NAP"),
+            "unprivileged": ("M", "ASY"),
+        }
+    },
+    {
+        "HeartDisease": {
+            ("M", "ASY"): np.inf,
+            ("M", "NAP"): np.inf,
+            ("M", "ATA"): np.inf,
+            ("F", "ASY"): np.inf,
+            ("F", "ATA"): np.inf,
+            ("F", "NAP"): np.nan,
+            ("M", "TA"): np.inf,
+            ("F", "TA"): np.nan,
+        }
+    },
+    {"HeartDisease": False},
+]
+
 
 @pytest.mark.parametrize(
     "data, threshold, expected_result",
@@ -1337,7 +1281,8 @@ eor_expected_result_3 = [
             dataset3,
             0.8,
             eor_expected_result_3,
-        ),  # rajouter un test ici
+        ),
+        (dataset6, None, eor_expected_result_6),
     ],
 )
 def test_equalised_odds_ratio(
@@ -1357,7 +1302,10 @@ def test_equalised_odds_ratio(
             for val, expected_val in zip(ranking.values(), expected_ranking.values()):
                 if not np.isnan(val) and not np.isnan(expected_val):
                     assert np.isclose(val, expected_val)
-        is_biased = eor.is_biased(threshold)
+        if threshold is None:
+            is_biased = eor.is_biased()
+        else:
+            is_biased = eor.is_biased(threshold)
         assert is_biased == expected_result[2]
     else:
         with expected_result:

--- a/tests/metrics/test_superset.py
+++ b/tests/metrics/test_superset.py
@@ -25,28 +25,28 @@ from fair_mango.metrics.superset import (
 
 df = pd.read_csv("tests/data/heart_data.csv")
 
-dataset1 = Dataset(df, ["Sex"], ["HeartDisease"])
+dataset1 = Dataset(df, ["Sex"], "HeartDisease")
 
-dataset2 = Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset2 = Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred")
 
-dataset3 = Dataset(df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"])
+dataset3 = Dataset(df, ["Sex", "ChestPainType"], "HeartDisease", "HeartDiseasePred")
 
-dataset4 = Dataset(df, ["Sex"], ["HeartDisease", "ExerciseAngina"], None, [1, "Y"])
+dataset4 = Dataset(df, ["Sex"], "HeartDisease", None, 1)
 
 dataset5 = Dataset(
     df,
     ["Sex"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "ExerciseAngina",
+    "ExerciseAnginaPred",
+    "Y",
 )
 
 dataset6 = Dataset(
     df,
     ["Sex", "ChestPainType"],
-    ["HeartDisease", "ExerciseAngina"],
-    ["HeartDiseasePred", "ExerciseAnginaPred"],
-    [1, "Y"],
+    "HeartDisease",
+    "HeartDiseasePred",
+    1,
 )
 
 
@@ -142,9 +142,7 @@ super_set_fairness_metrics_expected_result_3 = [
         ),
         (
             DisparateImpactRatio,
-            Dataset(
-                df, ["Sex", "ChestPainType"], ["HeartDisease"], ["HeartDiseasePred"]
-            ),
+            Dataset(df, ["Sex", "ChestPainType"], "HeartDisease", "HeartDiseasePred"),
             super_set_fairness_metrics_expected_result_2,
         ),
         (
@@ -231,7 +229,7 @@ super_set_performance_metrics_expected_result_2 = [
             super_set_performance_metrics_expected_result_2,
         ),
         (
-            Dataset(df, ["Sex"], ["HeartDisease"], ["HeartDiseasePred"]),
+            Dataset(df, ["Sex"], "HeartDisease", "HeartDiseasePred"),
             super_set_performance_metrics_expected_result_2,
         ),
     ],


### PR DESCRIPTION
- Updated Dataset class instantiation to accept single strings for real and predicted targets instead of lists.
- Adjusted related tests to reflect the new Dataset initialization format. (But they aren't all working)
- Modified metric classes to ensure consistency in handling target variables. 
-TO DO : fix the last tests (by the code or the expected results)