### PR TITLE
DEV: update pre-commit hooks to their latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,26 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: [--profile, black]
-
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.12.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.17.0
     hooks:
       - id: mypy
-        # --follow-imports skip should be deactivated when the project will be of a greater quality
-        # and that typing will be better throughout our modules
-        args: [--ignore-missing-imports, "--scripts-are-modules", "--follow-imports", "skip"]
-        additional_dependencies: ["types-requests", "types-PyYAML"]
+        args: [--ignore-missing-imports, "--scripts-are-modules"]


### PR DESCRIPTION
This PR brings the latest versions for all the pre-commit hooks, and removes some useless configuration and duplicated hooks.